### PR TITLE
Update RO and NF models to support costing

### DIFF
--- a/proteuslib/unit_models/nanofiltration_0D.py
+++ b/proteuslib/unit_models/nanofiltration_0D.py
@@ -12,8 +12,15 @@
 ##############################################################################
 
 # Import Pyomo libraries
-from pyomo.environ import Set, Var, Constraint, Param, Expression, SolverFactory, \
-    TerminationCondition, Suffix, NonNegativeReals, units as pyunits, Reference
+from pyomo.environ import (Block,
+                           Set,
+                           Var,
+                           Param,
+                           SolverFactory,
+                           Suffix,
+                           NonNegativeReals,
+                           Reference,
+                           units as pyunits)
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
@@ -472,6 +479,10 @@ class NanoFiltrationData(UnitModelBlockData):
             var_dict["Pressure Change"] = self.deltaP[time_point]
 
         return {"vars": var_dict}
+
+    def get_costing(self, module=None, **kwargs):
+        self.costing = Block()
+        module.NanoFiltration_costing(self.costing, **kwargs)
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -12,8 +12,14 @@
 ##############################################################################
 
 # Import Pyomo libraries
-from pyomo.environ import Var, Constraint, Set, Param, Expression, SolverFactory, \
-    TerminationCondition, Suffix, NonNegativeReals, units as pyunits, Reference
+from pyomo.environ import (Var,
+                           Set,
+                           Param,
+                           SolverFactory,
+                           Suffix,
+                           NonNegativeReals,
+                           Reference,
+                           Block)
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 # Import IDAES cores
@@ -417,6 +423,10 @@ class ReverseOsmosisData(UnitModelBlockData):
             var_dict["Pressure Change"] = self.deltaP[time_point]
 
         return {"vars": var_dict}
+
+    def get_costing(self, module=None, **kwargs):
+        self.costing = Block()
+        module.ReverseOsmosis_costing(self.costing, **kwargs)
 
     def calculate_scaling_factors(self):
         super().calculate_scaling_factors()


### PR DESCRIPTION
## Fixes/Addresses:

Fixes #39 

## Summary/Motivation:
Unit models should support external cost calculations. In order to do that they need a get_costing method.

## Changes proposed in this PR:
- Added `get_costing` method to RO and NF unit models to support
- Cleaned up imports

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
