### PR TITLE
Initial addition of concentration polarization to 0D RO model

### DIFF
--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -386,7 +386,6 @@ class ReverseOsmosisData(UnitModelBlockData):
                        b.properties_in[t].conc_mass_phase_comp['Liq', j] \
                        * self.cp_modulus[t, j]
 
-
         @self.feed_side.Constraint(self.flowsheet().config.time,
                                    self.solute_list,
                                    doc="Concentration polarization at the outlet")

--- a/proteuslib/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/tests/test_reverse_osmosis_0D.py
@@ -16,13 +16,16 @@ from pyomo.environ import (ConcreteModel,
                            TerminationCondition,
                            SolverStatus,
                            value,
+                           Param,
                            Var,
+                           Expression,
                            Constraint)
 from pyomo.network import Port
 from idaes.core import (FlowsheetBlock,
                         MaterialBalanceType,
                         EnergyBalanceType,
-                        MomentumBalanceType)
+                        MomentumBalanceType,
+                        ControlVolume0DBlock)
 from proteuslib.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
 import proteuslib.property_models.NaCl_prop_pack as props
 
@@ -43,6 +46,51 @@ solver = get_default_solver()
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.unit
+def test_config():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = props.NaClParameterBlock()
+    m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties})
+
+    assert len(m.fs.unit.config) == 9
+
+    assert not m.fs.unit.config.dynamic
+    assert not m.fs.unit.config.has_holdup
+    assert m.fs.unit.config.material_balance_type == \
+           MaterialBalanceType.useDefault
+    assert m.fs.unit.config.energy_balance_type == \
+           EnergyBalanceType.useDefault
+    assert m.fs.unit.config.momentum_balance_type == \
+           MomentumBalanceType.pressureTotal
+    assert not m.fs.unit.config.has_pressure_change
+    assert m.fs.unit.config.property_package is \
+           m.fs.properties
+    assert not m.fs.unit.config.has_concentration_polarization
+
+@pytest.mark.unit
+def test_option_has_pressure_change():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = props.NaClParameterBlock()
+    m.fs.unit = ReverseOsmosis0D(default={
+        "property_package": m.fs.properties,
+        "has_pressure_change": True})
+
+    assert isinstance(m.fs.unit.feed_side.deltaP, Var)
+    assert isinstance(m.fs.unit.deltaP, Var)
+
+@pytest.mark.unit
+def test_option_has_concentration_polarization():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = props.NaClParameterBlock()
+    m.fs.unit = ReverseOsmosis0D(default={
+        "property_package": m.fs.properties,
+        "has_pressure_change": True,
+        "has_concentration_polarization": True})
+
+    assert isinstance(m.fs.unit.cp_modulus, Var)
 
 class TestReverseOsmosis():
     @pytest.fixture(scope="class")
@@ -54,7 +102,8 @@ class TestReverseOsmosis():
 
         m.fs.unit = ReverseOsmosis0D(default={
             "property_package": m.fs.properties,
-            "has_pressure_change": True})
+            "has_pressure_change": True,
+            "has_concentration_polarization": True})
 
         # fully specify system
         feed_flow_mass = 1
@@ -66,6 +115,7 @@ class TestReverseOsmosis():
         A = 4.2e-12
         B = 3.5e-8
         pressure_atmospheric = 101325
+        concentration_polarization_modulus = 1.1
 
         feed_mass_frac_H2O = 1 - feed_mass_frac_NaCl
         m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(
@@ -79,107 +129,73 @@ class TestReverseOsmosis():
         m.fs.unit.A_comp.fix(A)
         m.fs.unit.B_comp.fix(B)
         m.fs.unit.permeate.pressure[0].fix(pressure_atmospheric)
+        m.fs.unit.cp_modulus.fix(concentration_polarization_modulus)
         return m
-
-    @pytest.mark.unit
-    def test_config(self, RO_frame):
-        m = RO_frame
-        # check unit config arguments
-        assert len(m.fs.unit.config) == 9
-
-        assert not m.fs.unit.config.dynamic
-        assert not m.fs.unit.config.has_holdup
-        assert m.fs.unit.config.material_balance_type == \
-               MaterialBalanceType.useDefault
-        assert m.fs.unit.config.energy_balance_type == \
-               EnergyBalanceType.useDefault
-        assert m.fs.unit.config.momentum_balance_type == \
-               MomentumBalanceType.pressureTotal
-        assert m.fs.unit.config.has_pressure_change
-        assert m.fs.unit.config.property_package is \
-               m.fs.properties
-        assert not m.fs.unit.config.has_concentration_polarization
 
     @pytest.mark.unit
     def test_build(self, RO_frame):
         m = RO_frame
 
-        # test ports and state variables
+        # test ports
         port_lst = ['inlet', 'retentate', 'permeate']
-        port_vars_lst = ['flow_mass_phase_comp', 'pressure', 'temperature']
         for port_str in port_lst:
-            assert hasattr(m.fs.unit, port_str)
             port = getattr(m.fs.unit, port_str)
-            assert len(port.vars) == 3
+            assert len(port.vars) == 3  # number of state variables for NaCl property package
             assert isinstance(port, Port)
-            for var_str in port_vars_lst:
-                assert hasattr(port, var_str)
-                var = getattr(port, var_str)
-                assert isinstance(var, Var)
 
-        # test unit objects (including parameters, variables, and constraints)
-        unit_objs_lst = ['A_comp', 'B_comp', 'dens_solvent',
-                         'flux_mass_phase_comp_in', 'flux_mass_phase_comp_out', 'area',
-                         'deltaP', 'mass_transfer_phase_comp', 'flux_mass_phase_comp_avg',
-                         ]
+        # test pyomo objects on unit
+        unit_objs_type_dict = {'dens_solvent': Param,
+                               'A_comp': Var,
+                               'B_comp': Var,
+                               'flux_mass_phase_comp_in': Var,
+                               'flux_mass_phase_comp_out': Var,
+                               'area': Var,
+                               'deltaP': Var,
+                               'cp_modulus': Var,
+                               'mass_transfer_phase_comp': Var,
+                               'flux_mass_phase_comp_avg': Expression,
+                               'eq_mass_transfer_term': Constraint,
+                               'eq_permeate_production': Constraint,
+                               'eq_flux_in': Constraint,
+                               'eq_flux_out': Constraint,
+                               'eq_connect_mass_transfer': Constraint,
+                               'eq_connect_enthalpy_transfer': Constraint,
+                               'eq_permeate_isothermal': Constraint}
+        for (obj_str, obj_type) in unit_objs_type_dict.items():
+            obj = getattr(m.fs.unit, obj_str)
+            assert isinstance(obj, obj_type)
+        # check that all added unit objects are tested
+        for obj in m.fs.unit.component_objects(
+                [Param, Var, Expression, Constraint], descend_into=False):
+            obj_str = obj.name[8::]  # remove leading "fs.unit."
+            assert obj_str in unit_objs_type_dict
 
-        unit_constr_lst = ['eq_mass_transfer_term', 'eq_permeate_production',
-                           'eq_flux_in', 'eq_flux_out',
-                           'eq_connect_mass_transfer', 'eq_connect_enthalpy_transfer',
-                           'eq_permeate_isothermal']
-        for obj_str in unit_objs_lst:
-            assert hasattr(m.fs.unit, obj_str)
-            
-        # TODO: test variables, constraints, expression separately (like done in prop pack); make var lists for
-        # interface and bulk; implement is_property_constructed for variables RO model needs?
+        # test control volume and associated stateblocks
+        assert isinstance(m.fs.unit.feed_side, ControlVolume0DBlock)
+        cv_stateblock_lst = ['properties_in', 'properties_out',
+                             'properties_interface_in', 'properties_interface_out']
+        for sb_str in cv_stateblock_lst:
+            sb = getattr(m.fs.unit.feed_side, sb_str)
+            assert isinstance(sb, props.NaClStateBlock)
+        # test objects added to control volume
+        cv_objs_type_dict = {'eq_concentration_polarization_in': Constraint,
+                             'eq_concentration_polarization_out': Constraint,
+                             'eq_equal_temp_interface_in': Constraint,
+                             'eq_equal_pressure_interface_in': Constraint,
+                             'eq_equal_flow_vol_interface_in': Constraint,
+                             'eq_equal_temp_interface_out': Constraint,
+                             'eq_equal_pressure_interface_out': Constraint,
+                             'eq_equal_flow_vol_interface_out': Constraint}
+        for (obj_str, obj_type) in cv_objs_type_dict.items():
+            obj = getattr(m.fs.unit.feed_side, obj_str)
+            assert isinstance(obj, obj_type)
 
-        cv_name = 'feed_side'
-
-        # test feed-side/membrane-interface relational constraints
-        cv_constraint_lst = ['eq_concentration_polarization_in', 'eq_concentration_polarization_out',
-                             'eq_equal_temp_inter_in', 'eq_equal_temp_inter_out',
-                             'eq_equal_pressure_inter_in', 'eq_equal_pressure_inter_out',
-                             'eq_equal_flow_vol_inter_in', 'eq_equal_flow_vol_inter_out']
-
-        # test state block objects for feed-side inlet/outlet, bulk and interface
-        cv_stateblock_lst = ['properties_in', 'properties_out', 'properties_inter_in', 'properties_inter_out']
-        stateblock_objs_lst = \
-            ['flow_mass_phase_comp', 'pressure', 'temperature', 'pressure_osm',
-             'osm_coeff', 'mass_frac_phase_comp', 'conc_mass_phase_comp',
-             'dens_mass_phase', 'enth_mass_phase',
-             'eq_pressure_osm', 'eq_osm_coeff', 'eq_mass_frac_phase_comp',
-             'eq_conc_mass_phase_comp', 'eq_dens_mass_phase', 'eq_enth_mass_phase']
-
-        # control volume
-        assert hasattr(m.fs.unit, cv_name)
-        cv_blk = getattr(m.fs.unit, cv_name)
-
-        # feed-side constraints
-        for constr_str in cv_constraint_lst:
-            # check that constraints exist on control volume
-            assert hasattr(cv_blk, constr_str)
-            blk_constr = getattr(cv_blk, constr_str)
-            # check that listed constraints on control volume are constraints
-            assert isinstance(blk_constr, Constraint)
-
-        # stateblocks on feed-side
-        for blk_str in cv_stateblock_lst:
-            # check that stateblocks exist for inlet and outlet for both the bulk and membrane interface
-            assert hasattr(cv_blk, blk_str)
-            blk = getattr(cv_blk, blk_str)
-            # check that listed attributes exist on each stateblock
-            for obj_str in stateblock_objs_lst:
-                assert hasattr(blk[0], obj_str)
-
-        # permeate
-        assert hasattr(m.fs.unit, 'properties_permeate')
-        blk = getattr(m.fs.unit, 'properties_permeate')
-        for var_str in stateblock_objs_lst:
-            assert hasattr(blk[0], var_str)
+        # test permeate stateblock
+        assert isinstance(m.fs.unit.properties_permeate, props.NaClStateBlock)
 
         # test statistics
-        assert number_variables(m) == 100
-        assert number_total_constraints(m) == 73
+        assert number_variables(m) == 93
+        assert number_total_constraints(m) == 65
         assert number_unused_variables(m) == 7  # vars from property package parameters
 
     @pytest.mark.unit
@@ -248,11 +264,11 @@ class TestReverseOsmosis():
     @pytest.mark.component
     def test_solution(self, RO_frame):
         m = RO_frame
-        assert (pytest.approx(5.574e-3, rel=1e-3) ==
+        assert (pytest.approx(4.682e-3, rel=1e-3) ==
                 value(m.fs.unit.flux_mass_phase_comp_avg[0, 'Liq', 'H2O']))
-        assert (pytest.approx(1.491e-6, rel=1e-3) ==
+        assert (pytest.approx(1.580e-6, rel=1e-3) ==
                 value(m.fs.unit.flux_mass_phase_comp_avg[0, 'Liq', 'NaCl']))
-        assert (pytest.approx(0.2787, rel=1e-3) ==
+        assert (pytest.approx(0.2341, rel=1e-3) ==
                 value(m.fs.unit.properties_permeate[0].flow_mass_phase_comp['Liq', 'H2O']))
-        assert (pytest.approx(7.453e-5, rel=1e-3) ==
+        assert (pytest.approx(7.901e-5, rel=1e-3) ==
                 value(m.fs.unit.properties_permeate[0].flow_mass_phase_comp['Liq', 'NaCl']))


### PR DESCRIPTION
## Fixes/Addresses:

Issue #11 

## Summary/Motivation:
The 0D-RO model requires more complexity. This PR focuses on the initial inclusion of the concentration polarization effect. 

## Changes proposed in this PR:
- Add binary configuration option for enabling concentration polarization
- Provide the following options: (1) no concentration polarization and (2) user specifies a value for the concentration polarization modulus (ratio of membrane interface concentration to the bulk concentration)
- The option to perform the full calculation will be added in a subsequent PR.
- Documentation for 0D-RO and any additional testing needed will be implemented in a subsequent PR.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
