### PR TITLE
Updating regression test truth values

### DIFF
--- a/proteuslib/tools/tests/test_parameter_sweep.py
+++ b/proteuslib/tools/tests/test_parameter_sweep.py
@@ -237,8 +237,8 @@ class TestParallelManager():
             # Attempt to read in the data
             data = np.genfromtxt('pytest_output/global_results.csv', skip_header=1, delimiter=',')
 
-            truth_data = [4.000000e+05, 1.469657e-11, 2.922988e-05, 2.000000e+01]
+            truth_data = [4.000000e+05, 1.311175e-11, 2.612842e-05, 2.000000e+01]
 
             # Compare the last row of the imported data to truth
             for k in range(len(truth_data)):
-                assert data[-1, k] == pytest.approx(truth_data[k])
+                assert data[-1, k] == pytest.approx(truth_data[k], rel=1e-5)


### PR DESCRIPTION
## Fixes/Addresses:

Quick fix to the truth data used in the regression test.

## Summary/Motivation:

The state of the repo used to generate the initial truth data was outdated and needed an update to reflect the latest version.  The current truth values are up to date and pass the regression test with either np=1 or np=2.

## Changes proposed in this PR:

Update truth values for regression test.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
