### PR TITLE
Deleting line that led to component tests being deselected

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts = -W ignore
           --durations=100
-          -m unit
           --cov
           --cov-config=.coveragerc
 testpaths = proteuslib


### PR DESCRIPTION
## Fixes/Addresses:

Quick fix to pytest.ini

## Summary/Motivation:

Component tests are not running. I deleted one line from pytest.ini to fix this.

## Changes proposed in this PR:
- Remove `-m unit` option


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
