### PR TITLE
Ph update01

### DIFF
--- a/proteuslib/tests/test_pure_water_pH.py
+++ b/proteuslib/tests/test_pure_water_pH.py
@@ -465,9 +465,20 @@ class TestPureWater():
                         'temperature': 298,
                         'flow_mol': 10
                     }
+        orig_fixed_vars = fixed_variables_set(model)
+        orig_act_consts = activated_constraints_set(model)
+        
         solver.options['bound_push'] = 1e-10
         solver.options['mu_init'] = 1e-6
         model.fs.unit.initialize(state_args=state_args, optarg=solver.options)
+
+        fin_fixed_vars = fixed_variables_set(model)
+        fin_act_consts = activated_constraints_set(model)
+
+        assert degrees_of_freedom(model) == 0
+
+        assert len(fin_act_consts) == len(orig_act_consts)
+        assert len(fin_fixed_vars) == len(orig_fixed_vars)
 
     @pytest.mark.component
     def test_initialize_equilibrium(self, equilibrium_reactions_config):
@@ -481,9 +492,20 @@ class TestPureWater():
                         'temperature': 298,
                         'flow_mol': 10
                     }
+        orig_fixed_vars = fixed_variables_set(model)
+        orig_act_consts = activated_constraints_set(model)
+
         solver.options['bound_push'] = 1e-10
         solver.options['mu_init'] = 1e-6
         model.fs.unit.initialize(state_args=state_args, optarg=solver.options)
+
+        fin_fixed_vars = fixed_variables_set(model)
+        fin_act_consts = activated_constraints_set(model)
+
+        assert degrees_of_freedom(model) == 0
+
+        assert len(fin_act_consts) == len(orig_act_consts)
+        assert len(fin_fixed_vars) == len(orig_fixed_vars)
 
     @pytest.mark.component
     def test_solve_inherent(self, inherent_reactions_config):


### PR DESCRIPTION
## Fixes/Addresses:

Adds assertions to unit tests that cover the initialization of the pH test problem. 

## Summary/Motivation:

New assertions ensure that the model doesn't change after the initialization stage. These same assertions were added to the alkalinity test and are being added here for testing consistency. 

## Changes proposed in this PR:
- Added new assertions to unit test for initialization of the pH control problem

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
