### PR TITLE
Only generating coverage for proteuslib

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = -W ignore
           --durations=100
-          --cov
+          --cov=proteuslib
           --cov-config=.coveragerc
 testpaths = proteuslib
 log_file = pytest.log


### PR DESCRIPTION
## Fixes/Addresses:

## Summary/Motivation:
Depending on how idaes/pyomo are installed, pytest-cov may generate coverage reports for idaes and pyomo. This PR corrects that issue.

## Changes proposed in this PR:
- Specifying `--cov=proteuslib` in pytest.ini

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
