### PR TITLE
updated initial values in seawater and NaCl packages

### DIFF
--- a/proteuslib/property_models/NaCl_prop_pack.py
+++ b/proteuslib/property_models/NaCl_prop_pack.py
@@ -306,7 +306,7 @@ class NaClStateBlockData(StateBlockData):
         self.flow_mass_phase_comp = Var(
             self.params.phase_list,
             self.params.component_list,
-            initialize=1,
+            initialize={('Liq', 'H2O'): 0.965, ('Liq', 'NaCl'): 0.035},
             bounds=(1e-8, None),
             domain=NonNegativeReals,
             units=pyunits.kg/pyunits.s,

--- a/proteuslib/property_models/seawater_prop_pack.py
+++ b/proteuslib/property_models/seawater_prop_pack.py
@@ -517,7 +517,7 @@ class SeawaterStateBlockData(StateBlockData):
         self.flow_mass_phase_comp = Var(
             self.params.phase_list,
             self.params.component_list,
-            initialize=1,
+            initialize={('Liq', 'H2O'): 0.965, ('Liq', 'TDS'): 0.035},
             bounds=(1e-8, None),
             domain=NonNegativeReals,
             units=pyunits.kg/pyunits.s,


### PR DESCRIPTION
## Fixes/Addresses:

partially addresses #91 

## Summary/Motivation:
Current default state variable values in the property model are infeasible, this updates them to more standard conditions.

## Changes proposed in this PR:
- Updated flow_mass_phase_comp initial values in seawater property package
- Updated flow_mass_phase_comp initial values in NaCl property package

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
