### PR TITLE
Fix readthedocs build errors and 1st draft of RO model documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,4 @@ sphinx:
 
 python:
    install:
-   - requirements: docs/requirements.txt
+   - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     fail_on_warning: true
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 import sphinx_rtd_theme
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 import sphinx_rtd_theme
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
 import sphinx_rtd_theme
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ version = '0.0.1'
 # ones.
 extensions = [
     'sphinx_rtd_theme',
+    'sphinx.ext.autodoc'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,17 @@ version = '0.0.1'
 # ones.
 extensions = [
     'sphinx_rtd_theme',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.doctest'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,9 @@ extensions = [
     'sphinx.ext.doctest'
 ]
 
+autosectionlabel_prefix_document = True
+
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 import sphinx_rtd_theme
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 import sphinx_rtd_theme
 sys.path.insert(0, os.path.abspath('..'))
-
+sys.path.insert(0,os.path.dirname(sys.path[0]))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/unit_models/0D_nanofiltration.rst
+++ b/docs/unit_models/0D_nanofiltration.rst
@@ -16,7 +16,7 @@ The main assumptions of the implemented model are as follows:
 
 1) Nanofiltration is modeled as cross-flow filtration as seen in Figure 1
 2) Model dimensionality is limited to 0D
-3) Model dynamics are restriced to steady-state only
+3) Model dynamics are restricted to steady-state only
 4) Single liquid phase only
 5) Single solute only (e.g. NaCl)
 6) Isothermal operation

--- a/docs/unit_models/index.rst
+++ b/docs/unit_models/index.rst
@@ -2,7 +2,7 @@ Unit Models
 ===========
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    
    0D_nanofiltration
    reverse_osmosis_0D

--- a/docs/unit_models/index.rst
+++ b/docs/unit_models/index.rst
@@ -5,3 +5,4 @@ Unit Models
    :maxdepth: 1
    
    0D_nanofiltration
+   reverse_osmosis_0D

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -6,10 +6,10 @@ This reverse osmosis (RO) unit model
    * supports steady-state only
    * is based on the solution-diffusion model and film theory
 
-#.. index::
-   #pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
+.. index::
+   pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
 
-#.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
+.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
 
 Example A: Setting up the RO model
 ----------------------------------
@@ -149,6 +149,7 @@ to eliminate that degree of freedom.
 On the other hand, in Example B, configuring the RO unit to calculate concentration polarization effects, mass transfer
 coefficient, and pressure drop would result in 3 more degrees of freedom than Example A. In this case, in addition to the
 previously fixed variables, we typically fix the following variables to fully specify the unit:
+
     * feed-spacer porosity
     * feed-channel height
     * membrane length *or* membrane width
@@ -210,12 +211,12 @@ Class Documentation
 -------------------
 
 
-###.. autoclass:: ReverseOsmosis0D
- #  #:members:
- #  #:noindex:
+.. autoclass:: ReverseOsmosis0D
+   :members:
+   :noindex:
 
-#.. autoclass:: ReverseOsmosisData
- # # :members:
-  # :noindex:
+.. autoclass:: ReverseOsmosisData
+   :members:
+   :noindex:
 
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -4,11 +4,7 @@ This reverse osmosis (RO) unit model:
    * is a 0-dimensional model
    * supports a single liquid phase only
    * supports steady-state only
-
-.. index::
-   pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
-
-.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
+   * is based on the solution-diffusion model and film theory
 
 Example
 -------

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -156,12 +156,22 @@ previously fixed variables, we typically fix the following variables to fully sp
 
 Model Structure
 ------------------
-#TODO: Feed-side: 0-D control volume
+Feed-side: 0-D control volume
 Permeate-side: state block
+
+Sets
+----
+.. csv-table::
+   :header: "Description", "Symbol", "Indices"
+
+   "time", ":math:`t`", "[0]"
+   "Inlet/outlet", ":math:`x`", "['in', 'out']"
+   "Phases", ":math:`p`", "['Liq']"
+   "Components", ":math:`j`", "['H2O', 'TDS']"
+
 
 Variables
 ----------
-#TODO:
 
 .. csv-table::
    :header: "Description", "Symbol", "Variable", "Index", "Units"

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -156,18 +156,19 @@ previously fixed variables, we typically fix the following variables to fully sp
 
 Model Structure
 ------------------
-Feed-side: 0-D control volume
-Permeate-side: state block
+This RO model consists of a ControlVolume0DBlock for the feed-channel of the membrane and a StateBlock for the permeate channel.
 
 Sets
 ----
 .. csv-table::
    :header: "Description", "Symbol", "Indices"
 
-   "time", ":math:`t`", "[0]"
+   "Time", ":math:`t`", "[0]"
    "Inlet/outlet", ":math:`x`", "['in', 'out']"
    "Phases", ":math:`p`", "['Liq']"
-   "Components", ":math:`j`", "['H2O', 'TDS']"
+   "Components", ":math:`j`", "['H2O', 'NaCl']*"
+
+* Solute depends on the imported property model; example shown here is for the NaCl property model.
 
 
 Variables
@@ -176,20 +177,13 @@ Variables
 .. csv-table::
    :header: "Description", "Symbol", "Variable", "Index", "Units"
 
-   "Component mass fraction", ":math:`x_j`", "mass_frac_phase_comp", "[p, j]", ":math:`\text{dimensionless}`"
-   "Mass density of seawater", ":math:`\rho`", "dens_mass_phase", "[p]", ":math:`\text{kg/}\text{m}^3`"
-   "Mass density of pure water", ":math:`\rho_w`", "dens_mass_w_phase", "[p]", ":math:`\text{kg/}\text{m}^3`"
-   "Phase volumetric flowrate", ":math:`Q_p`", "flow_vol_phase", "[p]", ":math:`\text{m}^3\text{/s}`"
-   "Volumetric flowrate", ":math:`Q`", "flow_vol", "None", ":math:`\text{m}^3\text{/s}`"
-   "Mass concentration", ":math:`C_j`", "conc_mass_phase_comp", "[p, j]", ":math:`\text{kg/}\text{m}^3`"
-   "Dynamic viscosity", ":math:`\mu`", "visc_d_phase", "[p]", ":math:`\text{Pa}\cdotp\text{s}`"
-   "Osmotic coefficient", ":math:`\phi`", "osm_coeff", "None", ":math:`\text{dimensionless}`"
-   "Specific enthalpy", ":math:`\widehat{H}`", "enth_mass_phase", "[p]", ":math:`\text{J/kg}`"
-   "Enthalpy flow", ":math:`H`", "enth_flow", "None", ":math:`\text{J/s}`"
-   "Saturation pressure", ":math:`P_v`", "pressure_sat", "None", ":math:`\text{Pa}`"
-   "Specific heat capacity", ":math:`c_p`", "cp_phase", "[p]", ":math:`\text{J/kg/K}`"
-   "Thermal conductivity", ":math:`\kappa`", "therm_cond_phase", "[p]", ":math:`\text{W/m/K}`"
-   "Latent heat of vaporization", ":math:`h_{vap}`", "dh_vap", "None", ":math:`\text{J/kg}`"
+   "Solvent permeability coefficient", ":math:`A`", "A_comp", "[t, j]", ":math:`\text{m/Pa/s}`"
+   "Solvent permeability coefficient", ":math:`B`", "B_comp", "[t, j]", ":math:`\text{m/s}`"
+   "Mass density of pure water", ":math:`\rho_w`", "dens_solvent", "[p]", ":math:`\text{kg/}\text{m}^3`"
+   "Mass flux across membrane", ":math:`J`", "flux_mass_io_phase_comp", "[t, x, p, j]", ":math:`\text{kg/s}\text{/m}^2`"
+   "Membrane area", ":math:`A_m`", "area", "None", ":math:`\text{m}^2`"
+   "Component recovery rate", ":math:`R_j`", "recovery_mass_phase_comp", "[t, p, j]", ":math:`\text{dimensionless}`"
+   "Volumetric recovery rate", ":math:`R`", "recovery_vol_phase", "[t, p]", ":math:`\text{dimensionless}`"
 
 
 Constraints
@@ -199,22 +193,7 @@ Constraints
 .. csv-table::
    :header: "Description", "Equation"
 
-   "Component mass fraction", ":math:`x_j = \frac{M_j}{\sum_{j} M_j}`"
-   "Mass density", "Equation 8 in Sharqawy et al. (2010)"
-   "Volumetric flowrate", ":math:`Q = \frac{\sum_{j} M_j}{\rho}`"
-   "Mass concentration", ":math:`C_j = x_j \cdotp \rho`"
-   "Dynamic viscosity", "Equations 22 and 23 in Sharqawy et al. (2010)"
-   "Osmotic coefficient", "Equation 49 in Sharqawy et al. (2010)"
-   "Specific enthalpy", "Equations 43 and 55 in Sharqawy et al. (2010)"
-   "Enthalpy flow", ":math:`H = \sum_{j} M_j \cdotp \widehat{H}`"
-   "Component mole flowrate", ":math:`N_j = \frac{M_j}{MW_j}`"
-   "Component mole fraction", ":math:`y_j = \frac{N_j}{\sum_{j} N_j}`"
-   "Molality", ":math:`Cm = \frac{x_{TDS}}{(1-x_{TDS}) \cdotp MW_{TDS}}`"
-   "Osmotic pressure", ":math:`\pi = \phi \cdotp Cm \cdotp \rho_w \cdotp R \cdotp T` [See note below]"
-   "Saturation pressure", "Equations 5 and 6 in Nayar et al. (2016)"
-   "Specific heat capacity", "Equation 9 in Sharqawy et al. (2010)"
-   "Thermal conductivity", "Equation 13 in Sharqawy et al. (2010)"
-   "Latent heat of vaporization", "Equations 37 and 55 in Sharqawy et al. (2010)"
+
 
 
 Class Documentation

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -6,10 +6,10 @@ This reverse osmosis (RO) unit model
    * supports steady-state only
    * is based on the solution-diffusion model and film theory
 
-.. index::
-   pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
+#.. index::
+   #pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
 
-.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
+#.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
 
 Example A: Setting up the RO model
 ----------------------------------
@@ -210,12 +210,12 @@ Class Documentation
 -------------------
 
 
-.. autoclass:: ReverseOsmosis0D
-   :members:
-   :noindex:
+###.. autoclass:: ReverseOsmosis0D
+ #  #:members:
+ #  #:noindex:
 
-.. autoclass:: ReverseOsmosisData
-   :members:
-   :noindex:
+#.. autoclass:: ReverseOsmosisData
+ # # :members:
+  # :noindex:
 
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -211,12 +211,12 @@ Class Documentation
 -------------------
 
 
-.. autoclass:: ReverseOsmosis0D
-   :members:
-   :noindex:
+#.. autoclass:: ReverseOsmosis0D
+   #:members:
+   #:noindex:
 
-.. autoclass:: ReverseOsmosisData
-   :members:
-   :noindex:
+#.. autoclass:: ReverseOsmosisData
+   #:members:
+   #:noindex:
 
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -212,8 +212,10 @@ Class Documentation
 
 .. autoclass:: ReverseOsmosis0D
    :members:
+   :noindex:
 
 .. autoclass:: ReverseOsmosisData
    :members:
+   :noindex:
 
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -211,12 +211,12 @@ Class Documentation
 -------------------
 
 
-#.. autoclass:: ReverseOsmosis0D
-   #:members:
-   #:noindex:
+.. autoclass:: ReverseOsmosis0D
+   :members:
+   :noindex:
 
-#.. autoclass:: ReverseOsmosisData
-   #:members:
-   #:noindex:
+.. autoclass:: ReverseOsmosisData
+   :members:
+   :noindex:
 
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -90,7 +90,7 @@ Configuration Keyword: ``pressure_change_type``
 
 **Notes:**
     * **to use any of the** ``pressure_change_type`` **options to account for pressure drop, the configuration keyword** ``has_pressure_change`` **must also be set to** ``True`` **.**
-    * **if a value is specified for pressure drop, it should be negative.**
+    * **if a value is specified for pressure change, it should be negative.**
 
 .. csv-table::
     :header: "Configuration Options", "Description"
@@ -208,6 +208,7 @@ Constraints
 
 Class Documentation
 -------------------
+
 
 .. autoclass:: ReverseOsmosis0D
    :members:

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -55,6 +55,7 @@ Configuration Options
 ---------------------
 In addition to the core configuration options that are normally included for an IDAES process block, the RO unit model
 contains options that account for concentration polarization, the mass transfer coefficient, and pressure drop.
+#TODO:
 
 .. csv-table::
    :header: "Keyword", "Value"
@@ -66,18 +67,17 @@ contains options that account for concentration polarization, the mass transfer 
 
 Degrees of Freedom
 ------------------
-This reverse osmosis (RO) unit model:
-   * is a 0-dimensional model
-   * supports a single liquid phase only
-   * supports steady-state only
+#TODO:Fill in later
 
 Model Structure
 ------------------
-Feed-side: 0-D control volume
+#TODO: Feed-side: 0-D control volume
 Permeate-side: state block
 
 Variables
 ----------
+#TODO:
+
 .. csv-table::
    :header: "Description", "Symbol", "Variable", "Index", "Units"
 
@@ -99,16 +99,8 @@ Variables
 
 Constraints
 -----------
-.. csv-table::
-   :header: "Description", "Symbol", "Variable", "Index", "Units"
+#TODO:
 
-   "Component mole flowrate", ":math:`N_j`", "flow_mol_phase_comp", "[p, j]", ":math:`\text{mole/s}`"
-   "Component mole fraction", ":math:`y_j`", "mole_frac_phase_comp", "[p, j]", ":math:`\text{dimensionless}`" 
-   "Molality", ":math:`Cm`", "molality_comp", "['TDS']", ":math:`\text{mole/kg}`"
-   "Osmotic pressure", ":math:`\pi`", "pressure_osm", "None", ":math:`\text{Pa}`"
-
-Relationships
--------------
 .. csv-table::
    :header: "Description", "Equation"
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -1,7 +1,7 @@
 Reverse Osmosis Unit (0D)
 =========================
-This reverse osmosis (RO) unit model:
-   * is a 0-dimensional model
+This reverse osmosis (RO) unit model
+   * is 0-dimensional
    * supports a single liquid phase only
    * supports steady-state only
    * is based on the solution-diffusion model and film theory
@@ -11,18 +11,23 @@ This reverse osmosis (RO) unit model:
 
 .. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
 
-Example
--------
+Example A: Setting up the RO model
+----------------------------------
 The example below shows how to setup a simple RO unit model.
 
 .. code-block:: python
 
+    # Import concrete model from Pyomo
+    from pyomo.environ import ConcreteModel
+    # Import flowsheet block from IDAES core
+    from idaes.core import FlowsheetBlock
     # Import NaCl property model
     import proteuslib.property_models.NaCl_prop_pack as props
     # Import utility tool for calculating scaling factors
-    import idaes.core.util.scaling as calculate_scaling_factors
-    #Import RO model
+    from idaes.core.util.scaling import calculate_scaling_factors
+    # Import RO model
     from proteuslib.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
+
 
     # Create a concrete model, flowsheet, and NaCl property parameter block.
     m = ConcreteModel()
@@ -33,44 +38,120 @@ The example below shows how to setup a simple RO unit model.
     m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties})
 
     # Specify system variables.
-    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(0.035) # mass flow rate of NaCl
+    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(0.035)  # mass flow rate of NaCl
     m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'H2O'].fix(0.965)  # mass flow rate of water
     m.fs.unit.inlet.pressure[0].fix(50e5)  # feed pressure
     m.fs.unit.inlet.temperature[0].fix(298.15)  # feed temperature
-    m.fs.unit.deltaP.fix(-3e5)  # membrane pressure drop
     m.fs.unit.area.fix(50)  # membrane area
     m.fs.unit.A_comp.fix(4.2e-12)  # membrane water permeability
     m.fs.unit.B_comp.fix(3.5e-8)  # membrane salt permeability
     m.fs.unit.permeate.pressure[0].fix(101325)  # permeate pressure
 
     # Set scaling factors for component mass flowrates.
-    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1, index=('Liq','H2O'))
-    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e2, index=('Liq','TDS'))
+    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1, index=('Liq', 'H2O'))
+    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e2, index=('Liq', 'NaCl'))
 
     # Calculate scaling factors.
-    calculate_scaling_factors(m.fs)
+    calculate_scaling_factors(m)
 
     # Initialize the model.
     m.fs.unit.initialize(optarg={'nlp_scaling_method': 'user-scaling'})
 
-
 Configuration Options
 ---------------------
-In addition to the core configuration options that are normally included for an IDAES process block, the RO unit model
+In addition to the core configuration options that are normally included for an IDAES control volume, the RO unit model
 contains options that account for concentration polarization, the mass transfer coefficient, and pressure drop.
-#TODO:
+
+**Default options denoted by** **
+
+Configuration Keyword: ``concentration_polarization_type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "Keyword", "Value"
+    :header: "Configuration Options", "Description"
 
-   "concentration_polarization_type", "ConcentrationPolarizationType.none"
-   "concentration_polarization_type", "ConcentrationPolarizationType.fixed"
-   "concentration_polarization_type", "ConcentrationPolarizationType.calculated"
+    "``ConcentrationPolarizationType.none`` **", "Simplifying assumption to ignore concentration polarization"
+    "``ConcentrationPolarizationType.fixed``", "Specify an estimated value for the concentration polarization modulus"
+    "``ConcentrationPolarizationType.calculated``", "Allow model to perform calculation of membrane-interface concentration"
 
+Configuration Keyword: ``mass_transfer_coefficient``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+    :header: "Configuration Options", "Description"
+
+    "``MassTransferCoefficient.none`` **", "Mass transfer coefficient not used in calculations"
+    "``MassTransferCoefficient.fixed``", "Specify an estimated value for the mass transfer coefficient in the feed channel"
+    "``MassTransferCoefficient.calculated``", "Allow model to perform calculation of mass transfer coefficient"
+
+
+Configuration Keyword: ``pressure_change_type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Notes:**
+    * **to use any of the** ``pressure_change_type`` **options to account for pressure drop, the configuration keyword** ``has_pressure_change`` **must also be set to** ``True`` **.**
+    * **if a value is specified for pressure drop, it should be negative.**
+
+.. csv-table::
+    :header: "Configuration Options", "Description"
+
+    "``PressureChangeType.fixed_per_stage`` **", "Specify an estimated value for pressure drop across the membrane feed channel"
+    "``PressureChangeType.fixed_per_unit_length``", "Specify an estimated value for pressure drop per unit length across the membrane feed channel"
+    "``PressureChangeType.calculated``", "Allow model to perform calculation of pressure drop across the membrane feed channel"
+
+Example B: Configure the RO model to account for concentration polarization and pressure drop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    # Import concrete model from Pyomo
+    from pyomo.environ import ConcreteModel
+    # Import flowsheet block from IDAES core
+    from idaes.core import FlowsheetBlock
+    # Import NaCl property model
+    import proteuslib.property_models.NaCl_prop_pack as props
+    # Import utility tool for calculating scaling factors
+    import idaes.core.util.scaling as calculate_scaling_factors
+    #Import RO model and configuration classes
+    from proteuslib.unit_models.reverse_osmosis_0D import (ReverseOsmosis0D,
+                                                           ConcentrationPolarizationType,
+                                                           MassTransferCoefficient,
+                                                           PressureChangeType)
+
+    # Create a concrete model, flowsheet, and NaCl property parameter block.
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = props.NaClParameterBlock()
+
+    # Add an RO unit to the flowsheet and specify configuration options to calculate effects of
+    # concentration polarization and pressure drop.
+    m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties,
+                                          "has_pressure_change": True,
+                                          "concentration_polarization_type": ConcentrationPolarizationType.calculated,
+                                          "mass_transfer_coefficient": MassTransferCoefficient.calculated,
+                                          "pressure_change_type": PressureChangeType.calculated})
 
 Degrees of Freedom
 ------------------
-#TODO:Fill in later
+Aside from the feed temperature, feed pressure, and component mass flow rates at the inlet, the RO model typically has
+at least 4 degrees of freedom that should be fixed for the unit to be fully specified.
+
+In Example A, the following variables were fixed, in addition to state variables at the inlet:
+    * membrane water permeability, A
+    * membrane salt permeability, B
+    * permeate pressure
+    * membrane area
+
+The degrees of freedom will depend on which RO configuration options are selected. For example, setting
+``has_pressure_change= True`` adds 1 degree of freedom. In this case, the pressure drop ``deltaP`` would need to be fixed
+to eliminate that degree of freedom.
+
+On the other hand, in Example B, configuring the RO unit to calculate concentration polarization effects, mass transfer
+coefficient, and pressure drop would result in 3 more degrees of freedom than Example A. In this case, in addition to the
+previously fixed variables, we typically fix the following variables to fully specify the unit:
+    * feed-spacer porosity
+    * feed-channel height
+    * membrane length *or* membrane width
 
 Model Structure
 ------------------

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -6,7 +6,7 @@ This reverse osmosis (RO) unit model:
    * supports steady-state only
 
 .. index::
-   pair: proteuslib.unit_models.reverse_osmosis_0D;ReverseOsmosis0D
+   pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
 
 .. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
 

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -6,6 +6,11 @@ This reverse osmosis (RO) unit model:
    * supports steady-state only
    * is based on the solution-diffusion model and film theory
 
+.. index::
+   pair: proteuslib.unit_models.reverse_osmosis_0D;reverse_osmosis_0D
+
+.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
+
 Example
 -------
 The example below shows how to setup a simple RO unit model.

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -1,0 +1,142 @@
+Reverse Osmosis Unit (0D)
+=========================
+This reverse osmosis (RO) unit model:
+   * is a 0-dimensional model
+   * supports a single liquid phase only
+   * supports steady-state only
+
+.. index::
+   pair: proteuslib.unit_models.reverse_osmosis_0D;ReverseOsmosis0D
+
+.. currentmodule:: proteuslib.unit_models.reverse_osmosis_0D
+
+Example
+-------
+The example below shows how to setup a simple RO unit model.
+
+.. code-block:: python
+
+    # Import NaCl property model
+    import proteuslib.property_models.NaCl_prop_pack as props
+    # Import utility tool for calculating scaling factors
+    import idaes.core.util.scaling as calculate_scaling_factors
+
+    # Create a concrete model, flowsheet, and NaCl property parameter block.
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(default={"dynamic": False})
+    m.fs.properties = props.NaClParameterBlock()
+
+    # Add an RO unit to the flowsheet.
+    m.fs.unit = ReverseOsmosis0D(default={"property_package": m.fs.properties})
+
+    # Specify system variables.
+    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'NaCl'].fix(0.035) # mass flow rate of NaCl
+    m.fs.unit.inlet.flow_mass_phase_comp[0, 'Liq', 'H2O'].fix(0.965)  # mass flow rate of water
+    m.fs.unit.inlet.pressure[0].fix(50e5)  # feed pressure
+    m.fs.unit.inlet.temperature[0].fix(298.15)  # feed temperature
+    m.fs.unit.deltaP.fix(-3e5)  # membrane pressure drop
+    m.fs.unit.area.fix(50)  # membrane area
+    m.fs.unit.A_comp.fix(4.2e-12)  # membrane water permeability
+    m.fs.unit.B_comp.fix(3.5e-8)  # membrane salt permeability
+    m.fs.unit.permeate.pressure[0].fix(101325)  # permeate pressure
+
+    # Set scaling factors for component mass flowrates.
+    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1, index=('Liq','H2O'))
+    m.fs.properties.set_default_scaling('flow_mass_phase_comp', 1e2, index=('Liq','TDS'))
+
+    # Calculate scaling factors.
+    calculate_scaling_factors(m.fs)
+
+    # Initialize the model.
+    m.fs.unit.initialize(optarg={'nlp_scaling_method': 'user-scaling'})
+
+
+Configuration Options
+---------------------
+In addition to the core configuration options that are normally included for an IDAES process block, the RO unit model
+contains options that account for concentration polarization, the mass transfer coefficient, and pressure drop.
+
+.. csv-table::
+   :header: "Keyword", "Value"
+
+   "concentration_polarization_type", "ConcentrationPolarizationType.none"
+   "concentration_polarization_type", "ConcentrationPolarizationType.fixed"
+   "concentration_polarization_type", "ConcentrationPolarizationType.calculated"
+
+
+Degrees of Freedom
+------------------
+This reverse osmosis (RO) unit model:
+   * is a 0-dimensional model
+   * supports a single liquid phase only
+   * supports steady-state only
+
+Model Structure
+------------------
+Feed-side: 0-D control volume
+Permeate-side: state block
+
+Variables
+----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable", "Index", "Units"
+
+   "Component mass fraction", ":math:`x_j`", "mass_frac_phase_comp", "[p, j]", ":math:`\text{dimensionless}`"
+   "Mass density of seawater", ":math:`\rho`", "dens_mass_phase", "[p]", ":math:`\text{kg/}\text{m}^3`"
+   "Mass density of pure water", ":math:`\rho_w`", "dens_mass_w_phase", "[p]", ":math:`\text{kg/}\text{m}^3`"
+   "Phase volumetric flowrate", ":math:`Q_p`", "flow_vol_phase", "[p]", ":math:`\text{m}^3\text{/s}`"
+   "Volumetric flowrate", ":math:`Q`", "flow_vol", "None", ":math:`\text{m}^3\text{/s}`"
+   "Mass concentration", ":math:`C_j`", "conc_mass_phase_comp", "[p, j]", ":math:`\text{kg/}\text{m}^3`"
+   "Dynamic viscosity", ":math:`\mu`", "visc_d_phase", "[p]", ":math:`\text{Pa}\cdotp\text{s}`"
+   "Osmotic coefficient", ":math:`\phi`", "osm_coeff", "None", ":math:`\text{dimensionless}`"
+   "Specific enthalpy", ":math:`\widehat{H}`", "enth_mass_phase", "[p]", ":math:`\text{J/kg}`"
+   "Enthalpy flow", ":math:`H`", "enth_flow", "None", ":math:`\text{J/s}`"
+   "Saturation pressure", ":math:`P_v`", "pressure_sat", "None", ":math:`\text{Pa}`"
+   "Specific heat capacity", ":math:`c_p`", "cp_phase", "[p]", ":math:`\text{J/kg/K}`"
+   "Thermal conductivity", ":math:`\kappa`", "therm_cond_phase", "[p]", ":math:`\text{W/m/K}`"
+   "Latent heat of vaporization", ":math:`h_{vap}`", "dh_vap", "None", ":math:`\text{J/kg}`"
+
+
+Constraints
+-----------
+.. csv-table::
+   :header: "Description", "Symbol", "Variable", "Index", "Units"
+
+   "Component mole flowrate", ":math:`N_j`", "flow_mol_phase_comp", "[p, j]", ":math:`\text{mole/s}`"
+   "Component mole fraction", ":math:`y_j`", "mole_frac_phase_comp", "[p, j]", ":math:`\text{dimensionless}`" 
+   "Molality", ":math:`Cm`", "molality_comp", "['TDS']", ":math:`\text{mole/kg}`"
+   "Osmotic pressure", ":math:`\pi`", "pressure_osm", "None", ":math:`\text{Pa}`"
+
+Relationships
+-------------
+.. csv-table::
+   :header: "Description", "Equation"
+
+   "Component mass fraction", ":math:`x_j = \frac{M_j}{\sum_{j} M_j}`"
+   "Mass density", "Equation 8 in Sharqawy et al. (2010)"
+   "Volumetric flowrate", ":math:`Q = \frac{\sum_{j} M_j}{\rho}`"
+   "Mass concentration", ":math:`C_j = x_j \cdotp \rho`"
+   "Dynamic viscosity", "Equations 22 and 23 in Sharqawy et al. (2010)"
+   "Osmotic coefficient", "Equation 49 in Sharqawy et al. (2010)"
+   "Specific enthalpy", "Equations 43 and 55 in Sharqawy et al. (2010)"
+   "Enthalpy flow", ":math:`H = \sum_{j} M_j \cdotp \widehat{H}`"
+   "Component mole flowrate", ":math:`N_j = \frac{M_j}{MW_j}`"
+   "Component mole fraction", ":math:`y_j = \frac{N_j}{\sum_{j} N_j}`"
+   "Molality", ":math:`Cm = \frac{x_{TDS}}{(1-x_{TDS}) \cdotp MW_{TDS}}`"
+   "Osmotic pressure", ":math:`\pi = \phi \cdotp Cm \cdotp \rho_w \cdotp R \cdotp T` [See note below]"
+   "Saturation pressure", "Equations 5 and 6 in Nayar et al. (2016)"
+   "Specific heat capacity", "Equation 9 in Sharqawy et al. (2010)"
+   "Thermal conductivity", "Equation 13 in Sharqawy et al. (2010)"
+   "Latent heat of vaporization", "Equations 37 and 55 in Sharqawy et al. (2010)"
+
+
+Class Documentation
+-------------------
+
+.. autoclass:: ReverseOsmosis0D
+   :members:
+
+.. autoclass:: ReverseOsmosisData
+   :members:
+
+

--- a/docs/unit_models/reverse_osmosis_0D.rst
+++ b/docs/unit_models/reverse_osmosis_0D.rst
@@ -20,6 +20,8 @@ The example below shows how to setup a simple RO unit model.
     import proteuslib.property_models.NaCl_prop_pack as props
     # Import utility tool for calculating scaling factors
     import idaes.core.util.scaling as calculate_scaling_factors
+    #Import RO model
+    from proteuslib.unit_models.reverse_osmosis_0D import ReverseOsmosis0D
 
     # Create a concrete model, flowsheet, and NaCl property parameter block.
     m = ConcreteModel()

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -14,22 +14,6 @@
 
 from enum import Enum
 from copy import deepcopy
-
-
-# Import IDAES cores
-from idaes.core import (ControlVolume0DBlock,
-                        declare_process_block_class,
-                        MaterialBalanceType,
-                        EnergyBalanceType,
-                        MomentumBalanceType,
-                        UnitModelBlockData,
-                        useDefault)
-from idaes.core.util.config import is_physical_parameter_block
-from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.util.testing import get_default_solver
-import idaes.core.util.scaling as iscale
-import idaes.logger as idaeslog
-
 # Import Pyomo libraries
 from pyomo.environ import (Var,
                            Set,
@@ -44,6 +28,19 @@ from pyomo.environ import (Var,
                            exp,
                            value)
 from pyomo.common.config import ConfigBlock, ConfigValue, In
+# Import IDAES cores
+from idaes.core import (ControlVolume0DBlock,
+                        declare_process_block_class,
+                        MaterialBalanceType,
+                        EnergyBalanceType,
+                        MomentumBalanceType,
+                        UnitModelBlockData,
+                        useDefault)
+from idaes.core.util.config import is_physical_parameter_block
+from idaes.core.util.exceptions import ConfigurationError
+from idaes.core.util.testing import get_default_solver
+import idaes.core.util.scaling as iscale
+import idaes.logger as idaeslog
 
 _log = idaeslog.getLogger(__name__)
 

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -819,16 +819,12 @@ class ReverseOsmosisData(UnitModelBlockData):
                     * (b.feed_side.properties_out[t].pressure_osm
                     - b.properties_permeate[t].pressure_osm))
 
-    def initialize(
-            blk,
-            initialize_guess=None,
-            state_args=None,
-            outlvl=idaeslog.NOTSET,
-            solver="ipopt",
-            optarg={"tol": 1e-6}):
+    def initialize(blk, initialize_guess=None, state_args=None, outlvl=idaeslog.NOTSET, solver="ipopt", optarg={"tol": 1e-6}):
         """
-        General wrapper for pressure changer initialization routines
+        General wrapper for RO initialization routines
+
         Keyword Arguments:
+
             initialize_guess : a dict of guesses for solvent_recovery, solute_recovery,
                                and cp_modulus. These guesses offset the initial values
                                for the retentate, permeate, and membrane interface

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -78,7 +78,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         domain=In([False]),
         default=False,
         description="Dynamic model flag - must be False",
-        doc="""Indicates whether this model will be dynamic or not,
+        doc="""Indicates whether this model will be dynamic or not.
     **default** = False. RO units do not support dynamic
     behavior."""))
     CONFIG.declare("has_holdup", ConfigValue(
@@ -92,7 +92,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=MaterialBalanceType.useDefault,
         domain=In(MaterialBalanceType),
         description="Material balance construction flag",
-        doc="""Indicates what type of mass balance should be constructed,
+        doc="""Indicates what type of mass balance should be constructed.
     **default** - MaterialBalanceType.useDefault.
     **Valid values:** {
     **MaterialBalanceType.useDefault - refer to property package for default
@@ -106,7 +106,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=EnergyBalanceType.useDefault,
         domain=In(EnergyBalanceType),
         description="Energy balance construction flag",
-        doc="""Indicates what type of energy balance should be constructed,
+        doc="""Indicates what type of energy balance should be constructed.
     **default** - EnergyBalanceType.useDefault.
     **Valid values:** {
     **EnergyBalanceType.useDefault - refer to property package for default
@@ -120,7 +120,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=MomentumBalanceType.pressureTotal,
         domain=In(MomentumBalanceType),
         description="Momentum balance construction flag",
-        doc="""Indicates what type of momentum balance should be constructed,
+        doc="""Indicates what type of momentum balance should be constructed.
     **default** - MomentumBalanceType.pressureTotal.
     **Valid values:** {
     **MomentumBalanceType.none** - exclude momentum balances,
@@ -132,8 +132,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=False,
         domain=In([True, False]),
         description="Pressure change term construction flag",
-        doc="""Indicates whether terms for pressure change should be
-    constructed,
+        doc="""Indicates whether terms for pressure change should be constructed.
     **default** - False.
     **Valid values:** {
     **True** - include pressure change terms,
@@ -142,7 +141,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=PressureChangeType.fixed_per_stage,
         domain=In(PressureChangeType),
         description="Pressure change term construction flag",
-        doc="""Indicates whether terms for pressure change should be
+        doc="""Indicates what type of pressure change calculation will be made.
     **default** - PressureChangeType.fixed_per_stage. 
     **Valid values:** {
     **PressureChangeType.fixed_per_stage** - user specifies pressure drop across membrane feed channel,
@@ -161,7 +160,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         implicit=True,
         description="Arguments to use for constructing property packages",
         doc="""A ConfigBlock with arguments to be passed to a property block(s)
-    and used when constructing these,
+    and used when constructing these.
     **default** - None.
     **Valid values:** {
     see property package for documentation.}"""))
@@ -169,7 +168,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=ConcentrationPolarizationType.none,
         domain=In(ConcentrationPolarizationType),
         description="External concentration polarization effect in RO",
-        doc="""Options to account for concentration polarization,
+        doc="""Options to account for concentration polarization.
     **default** - ConcentrationPolarizationType.none. 
     **Valid values:** {
     **ConcentrationPolarizationType.none** - assume no concentration polarization,
@@ -179,7 +178,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         default=MassTransferCoefficient.none,
         domain=In(MassTransferCoefficient),
         description="Mass transfer coefficient in RO feed channel",
-        doc="""Options to account for mass transfer coefficient,
+        doc="""Options to account for mass transfer coefficient.
     **default** - MassTransferCoefficient.none. 
     **Valid values:** {
     **MassTransferCoefficient.none** - mass transfer coefficient not included,

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -14,20 +14,7 @@
 
 from enum import Enum
 from copy import deepcopy
-# Import Pyomo libraries
-from pyomo.environ import (Var,
-                           Set,
-                           Param,
-                           SolverFactory,
-                           Suffix,
-                           NonNegativeReals,
-                           NegativeReals,
-                           Reference,
-                           Block,
-                           units as pyunits,
-                           exp,
-                           value)
-from pyomo.common.config import ConfigBlock, ConfigValue, In
+
 
 # Import IDAES cores
 from idaes.core import (ControlVolume0DBlock,
@@ -42,6 +29,21 @@ from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util.testing import get_default_solver
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
+
+# Import Pyomo libraries
+from pyomo.environ import (Var,
+                           Set,
+                           Param,
+                           SolverFactory,
+                           Suffix,
+                           NonNegativeReals,
+                           NegativeReals,
+                           Reference,
+                           Block,
+                           units as pyunits,
+                           exp,
+                           value)
+from pyomo.common.config import ConfigBlock, ConfigValue, In
 
 _log = idaeslog.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires=">=3.6, <4",
     install_requires=[
         # primary requirements for unit and property models
-        "idaes",
+        "idaes-pse",
         "pyomo",  # (also needed for units in electrolyte database (edb))
         # the following requirements are for the edb
         "pymongo>3",  # database interface

--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,11 @@ setup(
     packages=find_namespace_packages(),
     python_requires=">=3.6, <4",
     install_requires=[
-        # the following requirements are for the electrolyte database (edb)
+        # primary requirements for unit and property models
+        "idaes",
+        "pyomo",  # (also needed for units in electrolyte database (edb))
+        # the following requirements are for the edb
         "pymongo>3",  # database interface
-        "pyomo",  # units
         "fastjsonschema",  # schema validation
         # other requirements
         "pytest",  # technically developer, but everyone likes tests


### PR DESCRIPTION
## Fixes/Addresses:

Addresses #42
 
## Summary/Motivation:
Although this PR started as an attempt to add documentation for the 0D RO model, I discovered readthedocs build errors that also needed to be resolved. Thus, the intention is to merge my subtle fixes to resolve the build error while also submitting a 1st draft of the RO model documentation. The RO model documentation will be fortified (add lists of variables and constraints) in a subsequent PR.

## Changes proposed in this PR:
- add 1st draft of 0D-RO documentation
- insert required directory paths in docs/conf.py
- add a setting for Sphinx's autosectionlabel extension in docs.conf.py
- update readthedocs yaml
-  update setup.py to include idaes-pse

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
