### PR TITLE
Update initialization and tests to new get_solver method

### DIFF
--- a/proteuslib/property_models/seawater_prop_pack.py
+++ b/proteuslib/property_models/seawater_prop_pack.py
@@ -19,7 +19,7 @@ import idaes.logger as idaeslog
 
 # Import Pyomo libraries
 from pyomo.environ import Constraint, Expression, Reals, NonNegativeReals, \
-    Var, Param, Suffix, value, SolverFactory, log, log10, exp
+    Var, Param, Suffix, value, log, log10, exp
 from pyomo.environ import units as pyunits
 
 # Import IDAES cores
@@ -36,7 +36,7 @@ from idaes.core.util.constants import Constants
 from idaes.core.util.initialization import (fix_state_vars,
                                             revert_state_vars,
                                             solve_indexed_blocks)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.util.exceptions import PropertyPackageError
 import idaes.core.util.scaling as iscale
@@ -400,9 +400,9 @@ class _SeawaterStateBlock(StateBlock):
     whole, rather than individual elements of indexed Property Blocks.
     """
 
-    def initialize(self, state_args={}, state_vars_fixed=False,
+    def initialize(self, state_args=None, state_vars_fixed=False,
                    hold_state=False, outlvl=idaeslog.NOTSET,
-                   solver=None, optarg={}):
+                   solver=None, optarg=None):
         """
         Initialization routine for property package.
         Keyword Arguments:
@@ -449,16 +449,7 @@ class _SeawaterStateBlock(StateBlock):
         solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="properties")
 
         # Set solver and options
-        # TODO: clean up once IDAES new API for initialize solvers is released
-        if isinstance(solver, str):
-            opt = SolverFactory(solver)
-            opt.options = optarg
-        else:
-            if solver is None:
-                opt = get_default_solver()
-            else:
-                opt = solver
-                opt.options = optarg
+        opt = get_solver(solver, optarg)
 
         # Fix state variables
         flags = fix_state_vars(self, state_args)

--- a/proteuslib/property_models/tests/test_NaCl_prop_pack.py
+++ b/proteuslib/property_models/tests/test_NaCl_prop_pack.py
@@ -36,7 +36,7 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_solver
 from idaes.core.util.scaling import (calculate_scaling_factors,
                                      set_scaling_factor,
                                      unscaled_variables_generator,
@@ -46,7 +46,7 @@ from pyomo.util.check_units import assert_units_consistent, assert_units_equival
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit

--- a/proteuslib/property_models/tests/test_seawater_prop_pack.py
+++ b/proteuslib/property_models/tests/test_seawater_prop_pack.py
@@ -36,7 +36,7 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_total_constraints,
                                               number_unused_variables,
                                               unused_variables_set)
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_solver
 from idaes.core.util.scaling import (calculate_scaling_factors,
                                      set_scaling_factor,
                                      unscaled_variables_generator,
@@ -46,7 +46,7 @@ from pyomo.util.check_units import assert_units_consistent, assert_units_equival
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 solver.options["nlp_scaling_method"] = "user-scaling"
 
 # -----------------------------------------------------------------------------

--- a/proteuslib/unit_models/nanofiltration_0D.py
+++ b/proteuslib/unit_models/nanofiltration_0D.py
@@ -16,7 +16,6 @@ from pyomo.environ import (Block,
                            Set,
                            Var,
                            Param,
-                           SolverFactory,
                            Suffix,
                            NonNegativeReals,
                            Reference,
@@ -31,6 +30,7 @@ from idaes.core import (ControlVolume0DBlock,
                         MomentumBalanceType,
                         UnitModelBlockData,
                         useDefault)
+from idaes.core.util import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
 import idaes.core.util.scaling as iscale
@@ -402,8 +402,8 @@ class NanoFiltrationData(UnitModelBlockData):
             blk,
             state_args=None,
             outlvl=idaeslog.NOTSET,
-            solver="ipopt",
-            optarg={"tol": 1e-6}):
+            solver=None,
+            optarg=None):
         """
         General wrapper for pressure changer initialization routines
         Keyword Arguments:
@@ -412,18 +412,16 @@ class NanoFiltrationData(UnitModelBlockData):
                          initialization (see documentation of the specific
                          property package) (default = {}).
             outlvl : sets output level of initialization routine
-            optarg : solver options dictionary object (default={'tol': 1e-6})
+            optarg : solver options dictionary object (default=None)
             solver : str indicating which solver to use during
-                     initialization (default = 'ipopt')
+                     initialization (default = None)
         Returns:
             None
         """
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver options
-        # TODO: update with new initialization solver API for IDAES
-        opt = SolverFactory(solver)
-        opt.options = optarg
+        opt = get_solver(solver, optarg)
 
         # ---------------------------------------------------------------------
         # Initialize holdup block

--- a/proteuslib/unit_models/pressure_exchanger.py
+++ b/proteuslib/unit_models/pressure_exchanger.py
@@ -19,7 +19,6 @@ from pyomo.environ import (Block,
                            NonNegativeReals,
                            Reals,
                            value,
-                           SolverFactory,
                            units as pyunits)
 
 # Import IDAES cores
@@ -34,7 +33,7 @@ from idaes.core import (ControlVolume0DBlock,
 from idaes.core.util.initialization import revert_state_vars
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
 
 _log = idaeslog.getLogger(__name__)
@@ -261,18 +260,7 @@ class PressureExchangerData(UnitModelBlockData):
         solve_log = idaeslog.getSolveLogger(self.name, outlvl, tag="properties")
 
         # Set solver and options
-        # TODO: clean up once IDAES new API for initialize solvers is released
-        if optarg is None:
-            optarg = {}
-        if isinstance(solver, str):
-            opt = SolverFactory(solver)
-            opt.options = optarg
-        else:
-            if solver is None:
-                opt = get_default_solver()
-            else:
-                opt = solver
-                opt.options = optarg
+        opt = get_solver(solver, optarg)
 
         # initialize inlets
         flags_low_in = self.low_pressure_side.properties_in.initialize(

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -18,7 +18,6 @@ from copy import deepcopy
 from pyomo.environ import (Var,
                            Set,
                            Param,
-                           SolverFactory,
                            Suffix,
                            NonNegativeReals,
                            NegativeReals,
@@ -38,7 +37,7 @@ from idaes.core import (ControlVolume0DBlock,
                         useDefault)
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
-from idaes.core.util.testing import get_default_solver
+from idaes.core.util import get_solver
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
@@ -848,7 +847,7 @@ class ReverseOsmosisData(UnitModelBlockData):
                     * (b.feed_side.properties_out[t].pressure_osm
                     - b.properties_permeate[t].pressure_osm))
 
-    def initialize(blk, initialize_guess=None, state_args=None, outlvl=idaeslog.NOTSET, solver="ipopt", optarg={"tol": 1e-6}):
+    def initialize(blk, initialize_guess=None, state_args=None, outlvl=idaeslog.NOTSET, solver=None, optarg=None):
         """
         General wrapper for RO initialization routines
 
@@ -868,7 +867,7 @@ class ReverseOsmosisData(UnitModelBlockData):
                          feed side state block (see documentation of the specific
                          property package) (default = None).
             outlvl : sets output level of initialization routine
-            optarg : solver options dictionary object (default={'tol': 1e-6})
+            optarg : solver options dictionary object (default=None)
             solver : solver object or string indicating which solver to use during
                      initialization, if None provided the default solver will be used
                      (default = None)
@@ -878,16 +877,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         init_log = idaeslog.getInitLogger(blk.name, outlvl, tag="unit")
         solve_log = idaeslog.getSolveLogger(blk.name, outlvl, tag="unit")
         # Set solver and options
-        # TODO: clean up once IDAES new API for initialize solvers is released
-        if isinstance(solver, str):
-            opt = SolverFactory(solver)
-            opt.options = optarg
-        else:
-            if solver is None:
-                opt = get_default_solver()
-            else:
-                opt = solver
-                opt.options = optarg
+        opt = get_solver(solver, optarg)
 
         # assumptions
         if initialize_guess is None:

--- a/proteuslib/unit_models/tests/test_nanofiltration_0D.py
+++ b/proteuslib/unit_models/tests/test_nanofiltration_0D.py
@@ -26,12 +26,12 @@ from idaes.core import (FlowsheetBlock,
 from proteuslib.unit_models.nanofiltration_0D import NanoFiltration0D
 import proteuslib.property_models.NaCl_prop_pack as props
 
+from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import (calculate_scaling_factors,
                                      unscaled_variables_generator,
                                      unscaled_constraints_generator,
@@ -39,7 +39,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 
 class TestNanoFiltration():
     @pytest.fixture(scope="class")

--- a/proteuslib/unit_models/tests/test_pressure_exchanger.py
+++ b/proteuslib/unit_models/tests/test_pressure_exchanger.py
@@ -17,8 +17,7 @@ from pyomo.environ import (ConcreteModel,
                            Constraint,
                            TerminationCondition,
                            SolverStatus,
-                           value,
-                           SolverFactory)
+                           value)
 from pyomo.network import Port
 from idaes.core import (FlowsheetBlock,
                         MaterialBalanceType,
@@ -33,8 +32,8 @@ from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               fixed_variables_set,
                                               activated_constraints_set,
                                               number_unused_variables)
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util import get_solver
+from idaes.core.util.testing import initialization_tester
 from idaes.core.util.initialization import solve_indexed_blocks
 from idaes.core.util.exceptions import BalanceTypeNotSupportedError
 from idaes.core.util.scaling import (calculate_scaling_factors,
@@ -44,7 +43,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 
 
 # # -----------------------------------------------------------------------------
@@ -169,8 +168,7 @@ class TestPressureExchanger():
         m.fs.unit.high_pressure_side.properties_in[0].temperature.fix(temperature)
 
         # solve inlet conditions and only fix state variables (i.e. unfix flow_vol and mass_frac_phase)
-        solver = SolverFactory('ipopt')
-        solver.options = {'nlp_scaling_method': 'user-scaling'}
+        solver.options['nlp_scaling_method'] = 'user-scaling'
         results = solver.solve(m.fs.unit.low_pressure_side.properties_in[0])
         assert results.solver.termination_condition == TerminationCondition.optimal
         m.fs.unit.low_pressure_side.properties_in[0].flow_mass_phase_comp['Liq', 'TDS'].fix()
@@ -208,7 +206,7 @@ class TestPressureExchanger():
     @pytest.mark.component
     def test_initialize(self, unit_frame):
         m = unit_frame
-        kwargs = {'solver': solver,
+        kwargs = {'solver': 'ipopt',
                   'optarg': {'nlp_scaling_method': 'user-scaling'}}
         initialization_tester(unit_frame, **kwargs)
 

--- a/proteuslib/unit_models/tests/test_pump_isothermal.py
+++ b/proteuslib/unit_models/tests/test_pump_isothermal.py
@@ -22,9 +22,9 @@ from idaes.core import FlowsheetBlock
 from proteuslib.unit_models.pump_isothermal import Pump
 import proteuslib.property_models.seawater_prop_pack as props
 
+from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import degrees_of_freedom
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import (calculate_scaling_factors,
                                      unscaled_variables_generator,
                                      unscaled_constraints_generator,
@@ -34,7 +34,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 
 
 # -----------------------------------------------------------------------------

--- a/proteuslib/unit_models/tests/test_reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/tests/test_reverse_osmosis_0D.py
@@ -33,13 +33,13 @@ from proteuslib.unit_models.reverse_osmosis_0D import (ReverseOsmosis0D,
 import proteuslib.property_models.NaCl_prop_pack\
     as props
 
+from idaes.core.util import get_solver
 from idaes.core.util.model_statistics import (degrees_of_freedom,
                                               number_variables,
                                               number_total_constraints,
                                               number_unused_variables,
                                               variables_set)
-from idaes.core.util.testing import (get_default_solver,
-                                     initialization_tester)
+from idaes.core.util.testing import initialization_tester
 from idaes.core.util.scaling import (calculate_scaling_factors,
                                      unscaled_variables_generator,
                                      unscaled_constraints_generator,
@@ -49,7 +49,7 @@ from idaes.core.util.scaling import (calculate_scaling_factors,
 
 # -----------------------------------------------------------------------------
 # Get default solver for testing
-solver = get_default_solver()
+solver = get_solver()
 
 # -----------------------------------------------------------------------------
 @pytest.mark.unit


### PR DESCRIPTION
## Fixes/Addresses: #43

## Summary/Motivation:


## Changes proposed in this PR:
- Standardizes implementations of `initialize` to use the idaes `get_solver` function
- Cleans up some `initialize` default kwargs as a result of this change (and to eliminate mutable objects as defaults)
- Does some clean up of unneeded imports of `SolverFactory`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
