### PR TITLE
Adding linkcheck

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,4 +36,4 @@ jobs:
         pytest
     - name: Test documentation
       run: |
-        make -C docs doctest -d
+        make -C docs doctest linkcheck -d


### PR DESCRIPTION
## Fixes/Addresses:

## Summary/Motivation:
In #129 we noticed it would be nice to have automatic checking of links. Sphinx already implements this, so it's an easy fix.

## Changes proposed in this PR:
- Add `linkcheck` to the documentation test. 

NOTE: This doesn't really need to run for every Python version, perhaps we should have a separate GHA for this. That said, the doctests probably should run for every Python version; this is just a convenient place to add this check. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
