### PR TITLE
Limit linkcheck to one test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: Test documentation
+    - name: Test documentation code
       run: |
-        make -C docs doctest linkcheck -d
+        make -C docs doctest -d
+    # just run the linkcheck on one of the Pythons
+    # so we don't slam external sites
+    - name: Test documenation links
+      if: matrix.python-version == 3.9 
+      run: |
+        make -C docs linkcheck -d


### PR DESCRIPTION
## Fixes/Addresses:
Only need to run linkcheck once

## Summary/Motivation:
I implemented #131 in a hurry to get automated link testing the repo. However, when working on #130, we noticed that the linkcheck sometimes fails, perhpas because every Python version was hitting the web servers at a similar time.

## Changes proposed in this PR:
- Separate out linkcheck from doctest for easy identification of failure source
- Only run linkcheck on Python 3.9

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
