### PR TITLE
Extend GitHub Actions checks to include Windows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,11 +45,17 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --progress-bar off --upgrade pip
+        echo '::group::Output of "pip install" commands'
+        python -m pip install --progress-bar off --upgrade pip wheel setuptools
         pip install --progress-bar off -r requirements-dev.txt
+        echo '::endgroup::'
+        echo '::group::Output of "pip list/show" commands'
         pip list
         pip show idaes-pse
+        echo '::endgroup::'
+        echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --verbose
+        echo '::endgroup::'
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,8 @@ on:
 defaults:
   run:
     # important to make sure that all commands on Windows are run using Bash
-    shell: bash
+    # -l: login shell, needed when using Conda
+    shell: bash -l {0}
 
 jobs:
   tests:
@@ -40,8 +41,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: conda-incubator/setup-miniconda@v2
       with:
+        activate-environment: proteuslib-dev
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
@@ -49,7 +51,8 @@ jobs:
         python -m pip install --progress-bar off --upgrade pip wheel setuptools
         pip install --progress-bar off -r requirements-dev.txt
         echo '::endgroup::'
-        echo '::group::Output of "pip list/show" commands'
+        echo '::group::Display installed packages'
+        conda list
         pip list
         pip show idaes-pse
         echo '::endgroup::'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Checks
 
 on:
   push:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,14 +9,34 @@ on:
   pull_request:
     branches: [main]
 
+defaults:
+  run:
+    # important to make sure that all commands on Windows are run using Bash
+    shell: bash
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  tests:
+    name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        os:
+          - linux
+          - win64
+          # - macos
+        include:
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: win64
+            os-version: windows-2019
+          # - os: macos
+          #   os-version: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -36,9 +56,9 @@ jobs:
     - name: Test documentation code
       run: |
         make -C docs doctest -d
-    # just run the linkcheck on one of the Pythons
+    # just run the linkcheck on one of the jobs
     # so we don't slam external sites
     - name: Test documentation links
-      if: matrix.python-version == 3.9 
+      if: matrix.python-version == 3.9 && matrix.os == 'linux'
       run: |
         make -C docs linkcheck -d

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ The ProteusLib development repository.
 ProteusLib is developed as part of the [National Alliance for Water Innovation](https://nawihub.org/) project.
 
 ## Build Status
-[![Python package](https://github.com/nawi-hub/proteuslib/actions/workflows/python-package.yml/badge.svg)](https://github.com/nawi-hub/proteuslib/actions/workflows/python-package.yml)
+
+[![Checks](https://github.com/nawi-hub/proteuslib/actions/workflows/checks.yml/badge.svg)](https://github.com/nawi-hub/proteuslib/actions/workflows/checks.yml)
 [![Documentation Status](https://readthedocs.org/projects/proteuslib/badge/?version=latest)](https://proteuslib.readthedocs.io/en/latest/?badge=latest)
 
 ## Getting started

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         # tutorial tests
         "nbformat",
         # https://www.python.org/dev/peps/pep-0508/#environment-markers
-        'pywin32==225 ; platform_system=="Windows" and python_version>=3.8'
+        'pywin32==225 ; platform_system=="Windows" and python_version>="3.8"'
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,9 @@ setup(
         "fastjsonschema",  # schema validation
         "click",  # command-line tools with Click
         # tutorial tests
-        "nbformat"
+        "nbformat",
+        # https://www.python.org/dev/peps/pep-0508/#environment-markers
+        'pywin32==225 ; platform_system=="Windows" and python_version>=3.8'
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Fixes/Addresses #149 (indirectly)

## Summary/Motivation:

- Testing on Windows is important as it's the OS used by a large fraction of our user base (and, possibly, development team as well)
- With Windows enabled for GitHub Actions checks, issues such as #149 are likely to be caught already at the PR stage
- This PR extends the job matrix used to run our current checks to include Windows runners

## Changes proposed in this PR:
- Add Windows to job matrix
- Rename workflow to "Checks" (for greater clarity and consistency with the comprehensive CI infrastructure @ksbeattie and I are developing)
- Use a Conda environment to install and setup Python (for consistency with the "Getting started" installation guide in the documentation)
- Pin version of `pywin32` to 225 for Python 3.8 and 3.9, which is a (reasonably well-tested) workaround solving #149
   - This is a common issue unrelated to ProteusLib, see e.g. IDAES/idaes-pse#258

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
