### PR TITLE
Update pip install target to PyPI package

### DIFF
--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -51,7 +51,7 @@ If you are going to use ProteusLib's functionality, but *do not* plan to contrib
 
 	.. code-block:: shell
 
-		pip install https://github.com/nawi-hub/proteuslib/archive/main.zip
+		pip install proteuslib
 
 #. To verify that the installation was successful, open a Python interpreter and try importing some of ProteusLib's modules, e.g.:
 


### PR DESCRIPTION
## Summary/Motivation:

- In the installation docs, the default target for `pip install` should be the `proteuslib` PyPI package (now that we have one)

## Changes proposed in this PR:
- Update pip install target to `proteuslib` PyPI package in "Getting started" installation docs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
