### PR TITLE
Fix APIDOC warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,5 +18,6 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXAPIDOC) -f -M -H ProteusLib -d 3 -o apidoc ../proteuslib "../*tests*"
+#   TODO: Revisit %SPHINXAPIDOC% and get it working adequately with readthedocs
+#	@$(SPHINXAPIDOC) -f -M -H ProteusLib -d 3 -o apidoc ../proteuslib "../*tests*"
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,5 +48,7 @@ Indices and tables
 ------------------
 
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+
+..
+    TODO: Add back in if we build the whole API doc
+    * :ref:`modindex`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -28,8 +28,8 @@ if errorlevel 9009 (
 	echo.http://sphinx-doc.org/
 	exit /b 1
 )
-
-%SPHINXAPIDOC%  -f -M -H ProteusLib -d 3 -o apidoc ../proteuslib "../*tests*"
+REM TODO: Revisit %SPHINXAPIDOC% and get it working adequately with readthedocs
+REM %SPHINXAPIDOC%  -f -M -H ProteusLib -d 3 -o apidoc ../proteuslib "../*tests*"
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 


### PR DESCRIPTION
## Fixes/Addresses: #143 

## Summary/Motivation:

Commenting out %SPHINXAPIDOC% build line to avoid local warnings and check errors.

## Changes proposed in this PR:
- Comment out %SPHINXAPIDOC% build line and revisit at a later time


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
