### PR TITLE
Add reporting to 0DRO

### DIFF
--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -1055,7 +1055,7 @@ class ReverseOsmosisData(UnitModelBlockData):
         if hasattr(self, "width"):
             var_dict["Membrane Width"] = self.width
         if hasattr(self, "deltaP"):
-            var_dict["Pressure Drop"] = self.deltaP[time_point]
+            var_dict["Pressure Change"] = self.deltaP[time_point]
         if hasattr(self, "N_Re_io"):
             var_dict["Reynolds Number @Inlet"] = self.N_Re_io[time_point, 'in']
             var_dict["Reynolds Number @Outlet"] = self.N_Re_io[time_point, 'out']

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -12,7 +12,7 @@
 ###############################################################################
 
 
-from enum import Enum
+from enum import Enum, auto
 from copy import deepcopy
 # Import Pyomo libraries
 from pyomo.environ import (Var,
@@ -46,22 +46,22 @@ _log = idaeslog.getLogger(__name__)
 
 
 class ConcentrationPolarizationType(Enum):
-    none = 0        # simplified assumption: no concentration polarization
-    fixed = 1       # simplified assumption: concentration polarization modulus is a user specified value
-    calculated = 2  # calculate concentration polarization (concentration at membrane interface)
+    none = auto()                    # simplified assumption: no concentration polarization
+    fixed = auto()                   # simplified assumption: concentration polarization modulus is a user specified value
+    calculated = auto()              # calculate concentration polarization (concentration at membrane interface)
 
 
 class MassTransferCoefficient(Enum):
-    none = 0        # mass transfer coefficient not utilized for concentration polarization effect
-    fixed = 1       # mass transfer coefficient is a user specified value
-    calculated = 2  # mass transfer coefficient is calculated
+    none = auto()                    # mass transfer coefficient not utilized for concentration polarization effect
+    fixed = auto()                   # mass transfer coefficient is a user specified value
+    calculated = auto()              # mass transfer coefficient is calculated
     # TODO: add option for users to define their own relationship?
 
 
 class PressureChangeType(Enum):
-    fixed_per_stage = 1        # pressure drop across membrane channel is a user-specified value
-    fixed_per_unit_length = 2  # pressure drop per unit length across membrane channel is a user-specified value
-    calculated = 3             # pressure drop across membrane channel is calculated
+    fixed_per_stage = auto()         # pressure drop across membrane channel is a user-specified value
+    fixed_per_unit_length = auto()   # pressure drop per unit length across membrane channel is a user-specified value
+    calculated = auto()              # pressure drop across membrane channel is calculated
 
 
 @declare_process_block_class("ReverseOsmosis0D")
@@ -1047,6 +1047,8 @@ class ReverseOsmosisData(UnitModelBlockData):
 
     def _get_performance_contents(self, time_point=0):
         var_dict = {}
+        var_dict["Volumetric Recovery Rate"] = self.recovery_vol_phase[time_point, 'Liq']
+        var_dict["Solvent Mass Recovery Rate"] = self.recovery_mass_phase_comp[time_point, 'Liq', 'H2O']
         var_dict["Membrane Area"] = self.area
         if hasattr(self, "length"):
             var_dict["Membrane Length"] = self.length
@@ -1054,6 +1056,10 @@ class ReverseOsmosisData(UnitModelBlockData):
             var_dict["Membrane Width"] = self.width
         if hasattr(self, "deltaP"):
             var_dict["Pressure Change"] = self.deltaP[time_point]
+        if hasattr(self, "N_Re_io"):
+            var_dict["Inlet Reynolds Number"] = self.N_Re_io[time_point, 'in']
+        if hasattr(self, "N_Re_io"):
+            var_dict["Outlet Reynolds Number"] = self.N_Re_io[time_point, 'out']
         # TODO: add more vars
         return {"vars": var_dict}
 

--- a/proteuslib/unit_models/reverse_osmosis_0D.py
+++ b/proteuslib/unit_models/reverse_osmosis_0D.py
@@ -38,6 +38,7 @@ from idaes.core import (ControlVolume0DBlock,
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError
 from idaes.core.util import get_solver
+from idaes.core.util.tables import create_stream_table_dataframe
 import idaes.core.util.scaling as iscale
 import idaes.logger as idaeslog
 
@@ -1045,12 +1046,26 @@ class ReverseOsmosisData(UnitModelBlockData):
         )
 
     def _get_performance_contents(self, time_point=0):
-        # TODO: make a unit specific stream table
         var_dict = {}
+        var_dict["Membrane Area"] = self.area
+        if hasattr(self, "length"):
+            var_dict["Membrane Length"] = self.length
+        if hasattr(self, "width"):
+            var_dict["Membrane Width"] = self.width
         if hasattr(self, "deltaP"):
             var_dict["Pressure Change"] = self.deltaP[time_point]
-
+        # TODO: add more vars
         return {"vars": var_dict}
+
+    def _get_stream_table_contents(self, time_point=0):
+        return create_stream_table_dataframe(
+            {
+                "Feed Inlet": self.inlet,
+                "Feed Outlet": self.retentate,
+                "Permeate Outlet": self.permeate,
+            },
+            time_point=time_point,
+        )
 
     def get_costing(self, module=None, **kwargs):
         self.costing = Block()


### PR DESCRIPTION
## Fixes/Addresses:

This PR partially addresses  #56 and #93. 

## Summary/Motivation:

This PR adds vars to be reported by calling report() method after a solve:
e.g.,: `m.fs.unit.report()`

The user will see a report of 0DRO variables and a stream table showing state variables. The list of variables currently shown is not exhaustive, but this PR is meant to get the ball rolling on some form of reporting via the RO model. 

**Note:** check out the TODO note and let me know what you think. Furthermore, feel free to propose other key variables to add to the output.

## Changes proposed in this PR:
- adds variables to display in `_get_performance_contents()` method
- adds ports to display in `_get_stream_table_contents()` method

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
