### PR TITLE
Using comma delimiters in parameter_sweep

### DIFF
--- a/proteuslib/tools/parameter_sweep.py
+++ b/proteuslib/tools/parameter_sweep.py
@@ -421,7 +421,7 @@ def parameter_sweep(model, sweep_params, outputs, results_file=None, optimize_fu
         comm.Barrier()
 
     # Write a header string for all data files
-    data_header = ', '.join(itertools.chain(sweep_params,outputs))
+    data_header = ','.join(itertools.chain(sweep_params,outputs))
 
     if debugging_data_dir is not None:
         # Create the local filename and data
@@ -436,7 +436,7 @@ def parameter_sweep(model, sweep_params, outputs, results_file=None, optimize_fu
 
     if rank == 0 and results_file is not None:
         # Save the global data
-        np.savetxt(results_file, global_save_data, header=data_header, delimiter=', ', fmt='%.6e')
+        np.savetxt(results_file, global_save_data, header=data_header, delimiter=',', fmt='%.6e')
     
     return global_save_data
 


### PR DESCRIPTION
## Fixes/Addresses: N/A

## Summary/Motivation:
Currently, the output file generated by the parameter sweep tool uses `', '` as the delimiter, whereas the default for csv files is `','`. This makes parsing the output using a tool like pandas more cumbersome, at only a slight gain in readability (IMHO).

## Changes proposed in this PR:
- Switch the parameter sweep tool to use `','` as *the* delimiter in its output file.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
