### PR TITLE
Enable Codecov test coverage reports

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,6 +38,9 @@ jobs:
             os-version: windows-2019
           # - os: macos
           #   os-version: macos-10.15
+          # limit uploading coverage report for a single Python version in the matrix
+          - python-version: '3.8'
+            cov_report: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -59,9 +62,15 @@ jobs:
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --verbose
         echo '::endgroup::'
+    - name: Add coverage report options
+      if: matrix.cov_report
+      run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV
     - name: Test with pytest
       run: |
         pytest
+    - name: Upload coverage report to Codecov
+      if: matrix.cov_report
+      uses: codecov/codecov-action@v2
     - name: Test documentation code
       run: |
         make -C docs doctest -d


### PR DESCRIPTION
## Fixes/Addresses: #165 

## Summary/Motivation:

Once it is merged, this PR will enable Codecov reports for test coverage to be added to each PR. Once we see that Codecov is running smoothly, we can add a check that fails if the PR would cause the test coverage to decrease.

## Changes proposed in this PR:

- Set up GHA workflow to upload coverage report to Codecov for one Python version in the matrix

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
