### PR TITLE
Fixing issue with values iterator in parameter_sweep

### DIFF
--- a/proteuslib/tools/parameter_sweep.py
+++ b/proteuslib/tools/parameter_sweep.py
@@ -34,7 +34,8 @@ class _Sample(ABC):
     def __init__(self, pyomo_object, *args, **kwargs):
         # Check for indexed with single value
         if pyomo_object.is_indexed() and len(pyomo_object) == 1:
-            pyomo_object = pyomo_object.values()[0]
+            for _data_obj in pyomo_object.values():
+                pyomo_object = _data_obj
 
         # Make sure we are a Var() or Param()
         if not (pyomo_object.is_parameter_type() or pyomo_object.is_variable_type()):


### PR DESCRIPTION
## Fixes/Addresses:
Pyomo recently fixed a bug in the `values` method for indexed components (https://github.com/Pyomo/pyomo/pull/2007), which causes an issue in `parmeter_sweep._Sample`. The proposed change works if `values` returns a list or iterator.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
