### PR TITLE
Minor tweak of check_solve 

### DIFF
--- a/proteuslib/util/initialization.py
+++ b/proteuslib/util/initialization.py
@@ -45,7 +45,10 @@ def check_solve(results, checkpoint=None, logger=_log, fail_flag=False):
     if logger is None:
         raise ValueError('Set logger. For example, logger=init_log')
     if check_optimal_termination(results):
-        logger.info(f'{checkpoint} successful.')
+        if checkpoint is None:
+            logger.info(f'Solve successful.')
+        else:
+            logger.info(f'{checkpoint} successful.')
     else:
         if checkpoint is None:
             msg = f"The solver failed to converge to an optimal solution. " \


### PR DESCRIPTION
## Fixes/Addresses:

## Summary/Motivation:
This PR fixes the output from check_solve when a solve is successful. Previously, if a solve was successful, the printed/logged message was "None successful." 

## Changes proposed in this PR:
- minor fix to change message when solve is successful, but no string provided for `checkpoint`


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
