### PR TITLE
Add diffusivity to Seawater Property Model

### DIFF
--- a/docs/technical_reference/property_models/seawater.rst
+++ b/docs/technical_reference/property_models/seawater.rst
@@ -11,6 +11,7 @@ This seawater property package:
    * does not support dynamics
    * properties do not incorporate validity ranges for temperature and salinity
    * pressure-dependencies for property relationships are not incorporated
+   * assumes diffusivity of NaCl based on `Bartholomew & Mauter (2019) <https://doi.org/10.1016/j.memsci.2018.11.067>`_
 
 Sets
 ----
@@ -48,6 +49,7 @@ Properties
    "Specific heat capacity", ":math:`c_p`", "cp_phase", "[p]", ":math:`\text{J/kg/K}`"
    "Thermal conductivity", ":math:`\kappa`", "therm_cond_phase", "[p]", ":math:`\text{W/m/K}`"
    "Latent heat of vaporization", ":math:`h_{vap}`", "dh_vap", "None", ":math:`\text{J/kg}`"
+   "Diffusivity", ":math:`D`", "diffus_phase", "[p]", ":math:`\text{m}^2\text{/s}`"
 
 
 **The properties make use of the average molecular weight of sea salt, ≈ 31.40 g/mol, reported in the Reference-Composition Salinity Scale (Millero et al., 2008)  to convert to moles.**
@@ -81,6 +83,8 @@ Relationships
    "Specific heat capacity", "Equation 9 in Sharqawy et al. (2010)"
    "Thermal conductivity", "Equation 13 in Sharqawy et al. (2010)"
    "Latent heat of vaporization", "Equations 37 and 55 in Sharqawy et al. (2010)"
+   "Diffusivity", "Equation 6 in Bartholomew et al. (2010)"
+
 
 
 Note: Osmotic pressure calculation (based on equation 48 in Nayar et al. (2016)) uses the density of water as a function of temperature (:math:`\rho_w`) and the ideal gas constant (:math:`R\text{, 8.314 J/mol}\cdotp\text{K}`), in addition to previously defined variables.
@@ -126,6 +130,7 @@ The default scaling factors are as follows:
    * 1e-3 for the specific heat capacity
    * 1 for thermal conductivity
    * 1e-6 for latent heat of vaporization
+   * 1e9 for diffusivity
 
 Scaling factors for other variables can be calculated based on their relationships with the user-supplied or default scaling factors.
    
@@ -137,4 +142,7 @@ K.G.Nayar, M.H.Sharqawy, L.D.Banchik, and J.H.Lienhard V, "Thermophysical proper
 M.H. Sharqawy, J.H.L. V, S.M. Zubair, Thermophysical properties of seawater: a review of existing correlations and data, Desalination and Water Treatment. 16 (2010) 354–380. https://doi.org/10.5004/dwt.2010.1079. (2017 corrections provided at http://web.mit.edu/seawater )
 
 F.J. Millero, R. Feistel, D.G. Wright, T.J. McDougall, The composition of Standard Seawater and the definition of the Reference-Composition Salinity Scale, Deep-Sea Research Part I. 55 (2008) 50–72. https://doi.org/10.1016/j.dsr.2007.10.001.
+
+T.V. Bartholomew, M.S. Mauter, Computational framework for modeling membrane processes without process and solution property simplifications, Journal of Membrane Science. 573 (2019) 682–693. https://doi.org/10.1016/j.memsci.2018.11.067.
+
 

--- a/docs/technical_reference/property_models/seawater.rst
+++ b/docs/technical_reference/property_models/seawater.rst
@@ -83,7 +83,7 @@ Relationships
    "Specific heat capacity", "Equation 9 in Sharqawy et al. (2010)"
    "Thermal conductivity", "Equation 13 in Sharqawy et al. (2010)"
    "Latent heat of vaporization", "Equations 37 and 55 in Sharqawy et al. (2010)"
-   "Diffusivity", "Equation 6 in Bartholomew et al. (2010)"
+   "Diffusivity", "Equation 6 in Bartholomew et al. (2019)"
 
 
 
@@ -144,5 +144,4 @@ M.H. Sharqawy, J.H.L. V, S.M. Zubair, Thermophysical properties of seawater: a r
 F.J. Millero, R. Feistel, D.G. Wright, T.J. McDougall, The composition of Standard Seawater and the definition of the Reference-Composition Salinity Scale, Deep-Sea Research Part I. 55 (2008) 50–72. https://doi.org/10.1016/j.dsr.2007.10.001.
 
 T.V. Bartholomew, M.S. Mauter, Computational framework for modeling membrane processes without process and solution property simplifications, Journal of Membrane Science. 573 (2019) 682–693. https://doi.org/10.1016/j.memsci.2018.11.067.
-
 

--- a/proteuslib/property_models/seawater_prop_pack.py
+++ b/proteuslib/property_models/seawater_prop_pack.py
@@ -75,7 +75,12 @@ class SeawaterParameterData(PhysicalParameterBlock):
         - Mostafa H.Sharqawy, John H.Lienhard V, and Syed M.Zubair, "Thermophysical properties of seawater: A review of 
         existing correlations and data,"Desalination and Water Treatment, Vol.16, pp.354 - 380, April 2010.
         (2017 corrections provided at http://web.mit.edu/seawater)
+                
+        Diffusivity for NaCl is being used temporarily based on
+        Bartholomew & Mauter (2019) https://doi.org/10.1016/j.memsci.2018.11.067
         '''
+        #TODO: Edit comment above about diffusivity when/if relationship is changed
+
         # parameters
         # molecular weight
         mw_comp_data = {'H2O': 18.01528e-3,
@@ -156,6 +161,16 @@ class SeawaterParameterData(PhysicalParameterBlock):
         self.visc_d_param_B_3 = Var(
             within=Reals, initialize=4.724e-4, units=t_inv_units**2,
             doc='Dynamic viscosity parameter 3 for term B')
+
+        # diffusivity parameters, eq 6 in Bartholomew
+        diffus_param_dict = {'0': 1.51e-9, '1': -2.00e-9, '2': 3.01e-8,
+                             '3': -1.22e-7, '4': 1.53e-7}
+        self.diffus_param = Var(
+            diffus_param_dict.keys(),
+            domain=Reals,
+            initialize=diffus_param_dict,
+            units=pyunits.m ** 2 / pyunits.s,
+            doc='Dynamic viscosity parameters')
 
         # osmotic coefficient parameters, eq. 49 in Sharqawy
         self.osm_coeff_param_1 = Var(
@@ -360,6 +375,7 @@ class SeawaterParameterData(PhysicalParameterBlock):
         self.set_default_scaling('cp_phase', 1e-3, index='Liq')
         self.set_default_scaling('therm_cond_phase', 1e0, index='Liq')
         self.set_default_scaling('dh_vap', 1e-6)
+        self.set_default_scaling('diffus_phase', 1e9)
 
     @classmethod
     def define_metadata(cls, obj):
@@ -385,7 +401,9 @@ class SeawaterParameterData(PhysicalParameterBlock):
              'pressure_sat': {'method': '_pressure_sat'},
              'cp_phase': {'method': '_cp_phase'},
              'therm_cond_phase': {'method': '_therm_cond_phase'},
-             'dh_vap': {'method': '_dh_vap'}})
+             'dh_vap': {'method': '_dh_vap'},
+             'diffus_phase': {'method': '_diffus_phase'}
+             })
         # TODO: add diffusivity variable and constraint since it is needed when calculating mass transfer coefficient in
         #  current implementation of 0D RO model
         obj.add_default_units({'time': pyunits.s,
@@ -683,6 +701,23 @@ class SeawaterStateBlockData(StateBlockData):
                  + b.params.visc_d_param_B_3 * t**2)
             return b.visc_d_phase['Liq'] == mu_w * (1+A*s+B*s**2)
         self.eq_visc_d_phase = Constraint(rule=rule_visc_d_phase)
+
+    def _diffus_phase(self):  # TODO: diffusivity from NaCl prop model used temporarily--reconsider this
+        self.diffus_phase = Var(
+            self.params.phase_list,
+            initialize=1e-9,
+            bounds=(1e-10, 1e-8),
+            units=pyunits.m ** 2 * pyunits.s ** -1,
+            doc="Diffusivity")
+
+        def rule_diffus_phase(b):  # diffusivity, eq 6 in Bartholomew, substituting NaCl w/ TDS
+            return b.diffus_phase['Liq'] == (b.params.diffus_param['4'] * b.mass_frac_phase_comp['Liq', 'TDS'] ** 4
+                                             + b.params.diffus_param['3'] * b.mass_frac_phase_comp['Liq', 'TDS'] ** 3
+                                             + b.params.diffus_param['2'] * b.mass_frac_phase_comp['Liq', 'TDS'] ** 2
+                                             + b.params.diffus_param['1'] * b.mass_frac_phase_comp['Liq', 'TDS']
+                                             + b.params.diffus_param['0'])
+
+        self.eq_diffus_phase = Constraint(rule=rule_diffus_phase)
 
     def _osm_coeff(self):
         self.osm_coeff = Var(
@@ -986,7 +1021,7 @@ class SeawaterStateBlockData(StateBlockData):
 
         # property relationships with phase index, but simple constraint
         v_str_lst_phase = ['dens_mass_phase', 'flow_vol_phase', 'visc_d_phase', 'enth_mass_phase',
-                           'cp_phase', 'therm_cond_phase']
+                           'diffus_phase', 'cp_phase', 'therm_cond_phase']
         for v_str in v_str_lst_phase:
             if self.is_property_constructed(v_str):
                 v = getattr(self, v_str)

--- a/proteuslib/property_models/tests/test_seawater_prop_pack.py
+++ b/proteuslib/property_models/tests/test_seawater_prop_pack.py
@@ -32,8 +32,8 @@ class TestSeawaterProperty(PropertyTestHarness):
         self.param_args = {}
         self.scaling_args = {('flow_mass_phase_comp', ('Liq', 'H2O')): 1,
                              ('flow_mass_phase_comp', ('Liq', 'TDS')): 1e2}
-        self.stateblock_statistics = {'number_variables': 24,
-                                      'number_total_constraints': 20,
+        self.stateblock_statistics = {'number_variables': 25,
+                                      'number_total_constraints': 21,
                                       'number_unused_variables': 1,  # pressure is unused
                                       'default_degrees_of_freedom': 3}  # 4 state vars, but pressure is not active
         self.default_solution = {('mass_frac_phase_comp', ('Liq', 'H2O')): 0.965,
@@ -55,7 +55,8 @@ class TestSeawaterProperty(PropertyTestHarness):
                                  ('pressure_sat', None): 3111,
                                  ('cp_phase', 'Liq'): 4001,
                                  ('therm_cond_phase', 'Liq'): 0.6086,
-                                 ('dh_vap', None): 2.356e6}
+                                 ('dh_vap', None): 2.356e6,
+                                 ('diffus_phase', 'Liq'): 1.471e-9}
 
 
 @pytest.mark.component
@@ -92,7 +93,8 @@ class TestSeawaterPropertySolution_1(PropertyRegressionTest):
                                     ('pressure_sat', None): 1.229e4,
                                     ('cp_phase', 'Liq'): 4.130e3,
                                     ('therm_cond_phase', 'Liq'): 0.6400,
-                                    ('dh_vap', None): 2.358e6}
+                                    ('dh_vap', None): 2.358e6,
+                                    ('diffus_phase', 'Liq'): 1.493e-9}
 
 
 @pytest.mark.component
@@ -129,4 +131,5 @@ class TestSeawaterPropertySolution_2(PropertyRegressionTest):
                                     ('pressure_sat', None): 1.194e3,
                                     ('cp_phase', 'Liq'): 3.916e3,
                                     ('therm_cond_phase', 'Liq'): 0.5854,
-                                    ('dh_vap', None): 2.353e6}
+                                    ('dh_vap', None): 2.353e6,
+                                    ('diffus_phase', 'Liq'): 1.471e-9}

--- a/proteuslib/unit_models/reverse_osmosis_1D.py
+++ b/proteuslib/unit_models/reverse_osmosis_1D.py
@@ -1089,18 +1089,22 @@ class ReverseOsmosis1DData(UnitModelBlockData):
         if hasattr(self, "velocity") or self.config.has_full_reporting:
             var_dict["Velocity @Inlet"] = self.velocity[time_point, x_in]
             var_dict["Velocity @Outlet"] = self.velocity[time_point, x_out]
-        if interface_inlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
-            var_dict['Concentration @Inlet,Membrane-Interface '] = (
-                interface_inlet.conc_mass_phase_comp['Liq', 'NaCl'])
-        if interface_outlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
-            var_dict['Concentration @Outlet,Membrane-Interface '] = (
-                interface_outlet.conc_mass_phase_comp['Liq', 'NaCl'])
-        if feed_inlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
-            var_dict['Concentration @Inlet,Bulk'] = (
-                feed_inlet.conc_mass_phase_comp['Liq', 'NaCl'])
-        if feed_outlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
-            var_dict['Concentration @Outlet,Bulk'] = (
-                feed_outlet.conc_mass_phase_comp['Liq', 'NaCl'])
+        for j in self.config.property_package.solute_set:
+            if interface_inlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
+                var_dict[f'{j} Concentration @Inlet,Membrane-Interface '] = (
+                    interface_inlet.conc_mass_phase_comp['Liq', j])
+            if interface_outlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
+                var_dict[f'{j} Concentration @Outlet,Membrane-Interface '] = (
+                    interface_outlet.conc_mass_phase_comp['Liq', j])
+            if feed_inlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
+                var_dict[f'{j} Concentration @Inlet,Bulk'] = (
+                    feed_inlet.conc_mass_phase_comp['Liq', j])
+            if feed_outlet.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
+                var_dict[f'{j} Concentration @Outlet,Bulk'] = (
+                    feed_outlet.conc_mass_phase_comp['Liq', j])
+            if permeate.is_property_constructed('conc_mass_phase_comp') or self.config.has_full_reporting:
+                var_dict[f'{j} Permeate Concentration'] = (
+                    permeate.conc_mass_phase_comp['Liq', j])
         if interface_outlet.is_property_constructed('pressure_osm') or self.config.has_full_reporting:
             var_dict['Osmotic Pressure @Outlet,Membrane-Interface '] = (
                 interface_outlet.pressure_osm)
@@ -1124,9 +1128,11 @@ class ReverseOsmosis1DData(UnitModelBlockData):
 
         if self.config.has_full_reporting:
             expr_dict['Average Solvent Flux (LMH)'] = self.flux_mass_phase_comp_avg[time_point, 'Liq', 'H2O'] * 3.6e3
-            expr_dict['Average Solute Flux (GMH)'] = self.flux_mass_phase_comp_avg[time_point, 'Liq', 'NaCl'] * 3.6e6
             expr_dict['Average Reynolds Number'] = self.N_Re_avg[time_point]
-            expr_dict['Average Mass Transfer Coefficient (mm/h)'] = self.Kf_avg[time_point, 'NaCl'] * 3.6e6
+            for j in self.config.property_package.solute_set:
+                expr_dict[f'{j} Average Solute Flux (GMH)'] = self.flux_mass_phase_comp_avg[time_point, 'Liq', j] * 3.6e6
+                expr_dict[f'{j} Average Mass Transfer Coefficient (mm/h)'] = self.Kf_avg[time_point, j] * 3.6e6
+
 
         # TODO: add more vars
         return {"vars": var_dict, "exprs": expr_dict}

--- a/proteuslib/unit_models/tests/test_reverse_osmosis_1D.py
+++ b/proteuslib/unit_models/tests/test_reverse_osmosis_1D.py
@@ -304,8 +304,8 @@ class TestReverseOsmosis():
             assert isinstance(sb, props.NaClStateBlock)
 
         # test statistics
-        assert number_variables(m) == 248
-        assert number_total_constraints(m) == 205
+        assert number_variables(m) == 250
+        assert number_total_constraints(m) == 207
         assert number_unused_variables(m) == 20
 
     @pytest.mark.integration


### PR DESCRIPTION
## Fixes/Addresses: #63 
## Summary/Motivation:
This PR adds diffusivity to the seawater property model, which is needed by RO models. 

## Changes proposed in this PR:
- add diffusivity based on NaCl until better estimate representative of "average sea salt" arises
- add associated testing
- add to SW property model documentation
- revise RO model reporting methods to work with solutes other than NaCl

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
