### PR TITLE
Chemistry Scaling Docs

### DIFF
--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -4,7 +4,7 @@ How to scale chemical reactions
 ===============================
 
 ..warning::
-    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module. 
+    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
 
 No model in ProteusLib can solve without proper scaling of the constraints
 and variables within that model. This can be a difficult task for aqueous
@@ -38,7 +38,8 @@ different scenarios will be discussed and demonstrated below.
 
     IMPORTANT: Scaling of just the chemical reactions is insufficient for solving
     a chemistry module. User's MUST also scale the chemical species in the system
-    due to the dilute nature of aqueous chemistry. See TBD.
+    due to the dilute nature of aqueous chemistry. See
+    :ref:`How to scale chemical species<how_to_scale_chemical_species>`.
 
 
 Types of Reactions

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -3,7 +3,7 @@
 How to scale chemical reactions
 ===============================
 
-..warning::
+.. warning::
     DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
 
 No model in ProteusLib can solve without proper scaling of the constraints

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -22,6 +22,13 @@ different scenarios will be discussed and demonstrated below.
     see :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`.
 
 
+.. note::
+
+    The scaling factor constants used in these demonstrations are the best found
+    for these types of problems based on numerical testing of a variety of problems.
+    These values can and may need to change for your particular problem. 
+
+
 Types of Reactions
 ------------------
 
@@ -57,3 +64,15 @@ shows a demonstration of scaling factors that generally work well for these type
         iscale.set_scaling_factor(model.fs.unit.control_volume.inherent_reaction_extent[0.0,i[1]], 10/scale)
         iscale.constraint_scaling_transform(model.fs.unit.control_volume.properties_out[0.0].
                 inherent_equilibrium_constraint[i[1]], 0.1)
+
+
+What this code segment is doing is to first assign an **eps** value for the **log_power_law_equil**
+function. The default value is generally insufficient, so we change that value to always be at least
+4 orders of magnitude less than the **k_eq** value calculated for each reaction.
+
+Next, we create scaling factors for the **inherent_reaction_extent** variable based on the inverse
+of that calculated **k_eq** value.
+
+Lastly, we perform a scaling transformation of the **inherent_equilibrium_constraint**. In our case,
+we scale this constraint down by a factor of 0.1 because the **log_power_law_equil** constraint
+form is already scaled up reasonably well.

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -54,7 +54,8 @@ Types of Reactions
 Inherent Reactions using log_power_law_equil form
 -------------------------------------------------
 
-Inherent reactions (see Documentation Pending) are placed into the **GenericParameterBlock**
+Inherent reactions (see :ref:`How to use inherent reactions<how_to_use_inherent_reactions>`)
+are placed into the **GenericParameterBlock**
 rather than the **GenericReactionParameterBlock**. As such, the scaling methods employed
 must be applied to the **thermo_params** for this set of reactions. The code segment below
 shows a demonstration of scaling factors that generally work well for these types of reactions.

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -26,7 +26,7 @@ different scenarios will be discussed and demonstrated below.
 
     The scaling factor constants used in these demonstrations are the best found
     for these types of problems based on numerical testing of a variety of problems.
-    These values can and may need to change for your particular problem. 
+    These values can and may need to change for your particular problem.
 
 
 Types of Reactions
@@ -46,6 +46,9 @@ rather than the **GenericReactionParameterBlock**. As such, the scaling methods 
 must be applied to the **thermo_params** for this set of reactions. The code segment below
 shows a demonstration of scaling factors that generally work well for these types of reactions.
 
+
+Inherent Scaling Demonstration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block::
 

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -4,7 +4,7 @@ How to scale chemical reactions
 ===============================
 
 .. warning::
-    This scaling methods are meant to be used with the 'gradient-based' scaling
+    These scaling methods are meant to be used with the 'gradient-based' scaling
     functionality built into ipopt. It is not advised to use 'user-scaling' with
     the chemical modules, as this tends to have poor convergence. 
 

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -29,6 +29,13 @@ different scenarios will be discussed and demonstrated below.
     These values can and may need to change for your particular problem.
 
 
+.. note::
+
+    IMPORTANT: Scaling of just the chemical reactions is insufficient for solving
+    a chemistry module. User's MUST also scale the chemical species in the system
+    due to the dilute nature of aqueous chemistry. See TBD. 
+
+
 Types of Reactions
 ------------------
 
@@ -117,3 +124,28 @@ Equilibrium Scaling Demonstration
     These scaling arguments are identical to the **Inherent Reaction** scaling methods,
     however, because these reactions exist in a different location of the model, we
     showed this here for completeness. All reactions, regardless of location, need scaling.
+
+
+Rate Reactions using power_law_rate form
+----------------------------------------
+
+Rate reactions only exist in the **GenericReactionParameterBlock** and so these scaling
+arguments apply to **rxn_params** for these types of reactions. These are much simpler to
+scale than both the **Inherent** and **Equilibrium** reactions, but are just as important
+to apply scaling for. Below is a demonstration off applying scaling.
+
+Rate Reaction Scaling Demonstration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+    # Scaling for kinetic reactions
+    for i in model.fs.rxn_params.rate_reaction_idx:
+        scale = value(model.fs.unit.control_volume.reactions[0.0].reaction_rate[i].expr)
+        iscale.set_scaling_factor(model.fs.unit.control_volume.rate_reaction_extent[0.0,i], 10/scale)
+
+
+Stoichiometric Reactions
+------------------------
+
+TBD

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -1,0 +1,59 @@
+How to scale chemical reactions
+===============================
+
+No model in ProteusLib can solve without proper scaling of the constraints
+and variables within that model. This can be a difficult task for aqueous
+chemistry systems as these systems must deal with extremely dilute or trace
+chemical species and reaction coefficients that may vary from each other
+by several orders of magnitude.
+
+To scale a set of chemical reactions properly requires different function
+arguments to be invoked depending on: (i) where the reactions are located
+in the model and (ii) what types of reactions are called for. Each of these
+different scenarios will be discussed and demonstrated below.
+
+
+.. note::
+
+    The following guide and examples assume that your **GenericParameterBlock**
+    is named **thermo_params**, your **GenericReactionParameterBlock** is named
+    **rxn_params**, your unit model is named **unit**, and your **FlowsheetBlock**
+    is named **fs**. For information on setup of the basic chemistry modules,
+    see :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`.
+
+
+Types of Reactions
+------------------
+
+1. Inherent Reactions using log_power_law_equil form
+2. Equilibrium Reactions using log_power_law_equil form
+3. Rate Reactions using power_law_rate form
+4. Stoichiometric Reactions (Documentation Pending)
+
+
+Inherent Reactions using log_power_law_equil form
+-------------------------------------------------
+
+Inherent reactions (see Documentation Pending) are placed into the **GenericParameterBlock**
+rather than the **GenericReactionParameterBlock**. As such, the scaling methods employed
+must be applied to the **thermo_params** for this set of reactions. The code segment below
+shows a demonstration of scaling factors that generally work well for these types of reactions.
+
+
+.. code-block::
+
+    # Iterate through the reactions to set appropriate eps values
+    factor = 1e-4
+    for rid in model.fs.thermo_params.inherent_reaction_idx:
+        scale = value(model.fs.unit.control_volume.properties_out[0.0].k_eq[rid].expr)
+        # Want to set eps in some fashion similar to this
+        if scale < 1e-16:
+            model.fs.thermo_params.component("reaction_"+rid).eps.value = scale*factor
+        else:
+            model.fs.thermo_params.component("reaction_"+rid).eps.value = 1e-16*factor
+
+    for i in model.fs.unit.control_volume.inherent_reaction_extent_index:
+        scale = value(model.fs.unit.control_volume.properties_out[0.0].k_eq[i[1]].expr)
+        iscale.set_scaling_factor(model.fs.unit.control_volume.inherent_reaction_extent[0.0,i[1]], 10/scale)
+        iscale.constraint_scaling_transform(model.fs.unit.control_volume.properties_out[0.0].
+                inherent_equilibrium_constraint[i[1]], 0.1)

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -1,5 +1,10 @@
+.. _how_to_scale_chemical_reactions:
+
 How to scale chemical reactions
 ===============================
+
+..warning::
+    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module. 
 
 No model in ProteusLib can solve without proper scaling of the constraints
 and variables within that model. This can be a difficult task for aqueous
@@ -33,7 +38,7 @@ different scenarios will be discussed and demonstrated below.
 
     IMPORTANT: Scaling of just the chemical reactions is insufficient for solving
     a chemistry module. User's MUST also scale the chemical species in the system
-    due to the dilute nature of aqueous chemistry. See TBD. 
+    due to the dilute nature of aqueous chemistry. See TBD.
 
 
 Types of Reactions

--- a/docs/how_to_guides/how_to_scale_chemical_reactions.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_reactions.rst
@@ -4,7 +4,9 @@ How to scale chemical reactions
 ===============================
 
 .. warning::
-    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
+    This scaling methods are meant to be used with the 'gradient-based' scaling
+    functionality built into ipopt. It is not advised to use 'user-scaling' with
+    the chemical modules, as this tends to have poor convergence. 
 
 No model in ProteusLib can solve without proper scaling of the constraints
 and variables within that model. This can be a difficult task for aqueous
@@ -83,9 +85,11 @@ Inherent Scaling Demonstration
                 inherent_equilibrium_constraint[i[1]], 0.1)
 
 
-What this code segment is doing is to first assign an **eps** value for the **log_power_law_equil**
-function. The default value is generally insufficient, so we change that value to always be at least
-4 orders of magnitude less than the **k_eq** value calculated for each reaction.
+What this code segment is doing is to first assign an **eps** "smoothing" value for the **log_power_law_equil**
+function. While this value is not directly impactful to scaling, it is necessary to provide a reasonable
+estimate for the smoothing parameter, since a poor value will negatively impact convergence. The default value
+is generally insufficient, so we change that value to always be at least 4 orders of magnitude less than
+the **k_eq** value calculated for each reaction.
 
 Next, we create scaling factors for the **inherent_reaction_extent** variable based on the inverse
 of that calculated **k_eq** value.
@@ -139,7 +143,7 @@ Rate Reactions using power_law_rate form
 Rate reactions only exist in the **GenericReactionParameterBlock** and so these scaling
 arguments apply to **rxn_params** for these types of reactions. These are much simpler to
 scale than both the **Inherent** and **Equilibrium** reactions, but are just as important
-to apply scaling for. Below is a demonstration off applying scaling.
+to apply scaling for. Below is a demonstration of applying scaling.
 
 Rate Reaction Scaling Demonstration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,4 +159,6 @@ Rate Reaction Scaling Demonstration
 Stoichiometric Reactions
 ------------------------
 
-TBD
+.. note::
+
+    Documentation under development.

--- a/docs/how_to_guides/how_to_scale_chemical_species.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_species.rst
@@ -4,7 +4,9 @@ How to scale chemical species
 =============================
 
 .. warning::
-    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
+    This scaling methods are meant to be used with the 'gradient-based' scaling
+    functionality built into ipopt. It is not advised to use 'user-scaling' with
+    the chemical modules, as this tends to have poor convergence.
 
 In :ref:`How to scale chemical reactions<how_to_scale_chemical_reactions>`, we
 discussed at length how you need to apply scaling factors to variables and constraints
@@ -30,7 +32,7 @@ Scaling Chemical Species Example
     see :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`.
 
 For this example, our **GenericParameterBlock** (named **thermo_params**) is using
-the "state_definition" of **FTPx**. This may change how what variables the scaling
+the "state_definition" of **FTPx**. This may change what variables the scaling
 is applied to. See :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`
 for more information on "state_definition" options.
 

--- a/docs/how_to_guides/how_to_scale_chemical_species.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_species.rst
@@ -1,0 +1,7 @@
+.. _how_to_scale_chemical_species:
+
+How to scale chemical species
+=============================
+
+..warning::
+    DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.

--- a/docs/how_to_guides/how_to_scale_chemical_species.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_species.rst
@@ -3,7 +3,7 @@
 How to scale chemical species
 =============================
 
-..warning::
+.. warning::
     DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
 
 In :ref:`How to scale chemical reactions<how_to_scale_chemical_reactions>`, we

--- a/docs/how_to_guides/how_to_scale_chemical_species.rst
+++ b/docs/how_to_guides/how_to_scale_chemical_species.rst
@@ -5,3 +5,48 @@ How to scale chemical species
 
 ..warning::
     DO NOT use 'user-scaling' as a solver option when scaling any chemistry module.
+
+In :ref:`How to scale chemical reactions<how_to_scale_chemical_reactions>`, we
+discussed at length how you need to apply scaling factors to variables and constraints
+associated with all the different types of reactions your system may have. Here,
+we will add to that discussion how the variables for the chemical species in the
+system should also be scaled.
+
+.. note::
+
+    The scaling factor constants used in this demonstration are the best found
+    for these types of problems based on numerical testing of a variety of problems.
+    These values can and may need to change for your particular problem.
+
+
+Scaling Chemical Species Example
+--------------------------------
+
+.. note::
+
+    The following example assumes that your unit model is named **unit** and
+    your **FlowsheetBlock** is named **fs**. For information on setup of the
+    basic chemistry modules,
+    see :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`.
+
+For this example, our **GenericParameterBlock** (named **thermo_params**) is using
+the "state_definition" of **FTPx**. This may change how what variables the scaling
+is applied to. See :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`
+for more information on "state_definition" options.
+
+.. code-block::
+
+    # Try adding scaling for species
+    min = 1e-6
+    for i in model.fs.unit.control_volume.properties_out[0.0].mole_frac_phase_comp:
+        # i[0] = phase, i[1] = species
+        if model.fs.unit.inlet.mole_frac_comp[0, i[1]].value > min:
+            scale = model.fs.unit.inlet.mole_frac_comp[0, i[1]].value
+        else:
+            scale = min
+        iscale.set_scaling_factor(model.fs.unit.control_volume.properties_out[0.0].mole_frac_comp[i[1]], 10/scale)
+        iscale.set_scaling_factor(model.fs.unit.control_volume.properties_out[0.0].mole_frac_phase_comp[i], 10/scale)
+        iscale.set_scaling_factor(model.fs.unit.control_volume.properties_out[0.0].flow_mol_phase_comp[i], 10/scale)
+        iscale.constraint_scaling_transform(
+            model.fs.unit.control_volume.properties_out[0.0].component_flow_balances[i[1]], 10/scale)
+        iscale.constraint_scaling_transform(model.fs.unit.control_volume.material_balances[0.0,i[1]], 10/scale)

--- a/docs/how_to_guides/how_to_setup_simple_chemistry.rst
+++ b/docs/how_to_guides/how_to_setup_simple_chemistry.rst
@@ -41,7 +41,7 @@ What you will need
     required for others. Additionally, certain reactions can actually be defined
     in the **thermo-properties** dictionary and would therefore NOT be included in
     the **reaction-properties** dictionary. The differences will be covered in another
-    how-to guide.
+    how-to guide (see :ref:`How to use inherent reactions<how_to_use_inherent_reactions>`)
 
 
 The **thermo-properties** configuration dictionary
@@ -243,8 +243,9 @@ options available. More information can be found in `StateDefinition`_.
 The **reaction-properties** configuration dictionary
 ----------------------------------------------------
 
-If you did not include reactions in the **thermo-properties** dictionary (a topic
-discussed later) and your system involves reactions, then you MUST also create and
+If you did not include reactions in the **thermo-properties** dictionary
+(see :ref:`How to use inherent reactions<how_to_use_inherent_reactions>`)
+and your system involves reactions, then you MUST also create and
 provide a **reaction-properties** configuration dictionary. Unlike the **thermo-properties**
 configuration dictionary, most of the keys within the **reaction-properties** dictionary
 are optional and depend on your system. The major keys to be aware of are as follows...

--- a/docs/how_to_guides/how_to_setup_simple_chemistry.rst
+++ b/docs/how_to_guides/how_to_setup_simple_chemistry.rst
@@ -285,7 +285,7 @@ reaction, we will model it as an equilibrium reaction.
     from idaes.generic_models.properties.core.reactions.dh_rxn import constant_dh_rxn
 
     # Import built-in Gibb's Energy function
-    from idaes.generic_models.properties.core.reactions.equilibrium_constant import gibbs_energy
+    from idaes.generic_models.properties.core.reactions.equilibrium_constant import van_t_hoff
 
     # Import safe log power law equation
     from idaes.generic_models.properties.core.reactions.equilibrium_forms import log_power_law_equil
@@ -305,13 +305,13 @@ reaction, we will model it as an equilibrium reaction.
                                      ("Liq", "H_+"): 1,
                                      ("Liq", "OH_-"): 1},
                    "heat_of_reaction": constant_dh_rxn,
-                   "equilibrium_constant": gibbs_energy,
+                   "equilibrium_constant": van_t_hoff,
                    "equilibrium_form": log_power_law_equil,
-                   "concentration_form": ConcentrationForm.molarity,
+                   "concentration_form": ConcentrationForm.moleFraction,
                    "parameter_data": {
                        "dh_rxn_ref": (55.830, pyunits.kJ/pyunits.mol),
-                       "ds_rxn_ref": (-80.7, pyunits.J/pyunits.mol/pyunits.K),
-                       "T_eq_ref": (300, pyunits.K),
+                       "k_eq_ref": (10**-14/55.2/55.2, pyunits.dimensionless),
+                       "T_eq_ref": (298, pyunits.K),
 
                        # By default, reaction orders follow stoichiometry, so
                        #    we manually set reaction order here to override.

--- a/docs/how_to_guides/how_to_use_inherent_reactions.rst
+++ b/docs/how_to_guides/how_to_use_inherent_reactions.rst
@@ -29,3 +29,275 @@ will be unique to a specific unit process.
 
 Example **thermo_config**
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this example, we will define a simple thermo-properties configuration dictionary
+for a chemical system that contains only water. The water dissociation reaction will
+be declared as **inherent** and, thus, be a part of this configuration dictionary.
+
+.. testsetup::
+
+   # quiet idaes logs
+   import idaes.logger as idaeslogger
+   idaeslogger.getLogger('ideas.core').setLevel('CRITICAL')
+   idaeslogger.getLogger('idaes.init').setLevel('CRITICAL')
+
+.. testcode::
+
+    # Importing the object for units from pyomo
+    from pyomo.environ import units as pyunits
+
+    # Imports from idaes core
+    from idaes.core import AqueousPhase
+    from idaes.core.components import Solvent, Cation, Anion
+
+    # Imports from idaes generic models
+    import idaes.generic_models.properties.core.pure.Perrys as Perrys
+    from idaes.generic_models.properties.core.pure.ConstantProperties import Constant
+    from idaes.generic_models.properties.core.state_definitions import FTPx
+    from idaes.generic_models.properties.core.eos.ideal import Ideal
+
+    # Importing the object for units from pyomo
+    from pyomo.environ import units as pyunits
+
+    # Import the object/function for heat of reaction
+    from idaes.generic_models.properties.core.reactions.dh_rxn import constant_dh_rxn
+
+    # Import built-in Gibb's Energy function
+    from idaes.generic_models.properties.core.reactions.equilibrium_constant import van_t_hoff
+
+    # Import safe log power law equation
+    from idaes.generic_models.properties.core.reactions.equilibrium_forms import log_power_law_equil
+
+    # Importing the enum for concentration unit basis used in the 'get_concentration_term' function
+    from idaes.generic_models.properties.core.generic.generic_reaction import ConcentrationForm
+
+    # Configuration dictionary
+    thermo_config = {
+        "components": {
+            'H2O': {"type": Solvent,
+                  # Define the methods used to calculate the following properties
+                  "dens_mol_liq_comp": Perrys,
+                  "enth_mol_liq_comp": Perrys,
+                  "cp_mol_liq_comp": Perrys,
+                  "entr_mol_liq_comp": Perrys,
+                  # Parameter data is always associated with the methods defined above
+                  "parameter_data": {
+                        "mw": (18.0153, pyunits.g/pyunits.mol),
+                        # Parameters here come from Perry's Handbook:  p. 2-98
+                        "dens_mol_liq_comp_coeff": {
+                            '1': (5.459, pyunits.kmol*pyunits.m**-3),
+                            '2': (0.30542, pyunits.dimensionless),
+                            '3': (647.13, pyunits.K),
+                            '4': (0.081, pyunits.dimensionless)},
+                        "enth_mol_form_liq_comp_ref": (-285.830, pyunits.kJ/pyunits.mol),
+                        "enth_mol_form_vap_comp_ref": (0, pyunits.kJ/pyunits.mol),
+                        # Parameters here come Perry's Handbook:  p. 2-174
+                        "cp_mol_liq_comp_coeff": {
+                            '1': (2.7637E5, pyunits.J/pyunits.kmol/pyunits.K),
+                            '2': (-2.0901E3, pyunits.J/pyunits.kmol/pyunits.K**2),
+                            '3': (8.125, pyunits.J/pyunits.kmol/pyunits.K**3),
+                            '4': (-1.4116E-2, pyunits.J/pyunits.kmol/pyunits.K**4),
+                            '5': (9.3701E-6, pyunits.J/pyunits.kmol/pyunits.K**5)},
+                        "cp_mol_ig_comp_coeff": {
+                            'A': (30.09200, pyunits.J/pyunits.mol/pyunits.K),
+                            'B': (6.832514, pyunits.J*pyunits.mol**-1*pyunits.K**-1*pyunits.kiloK**-1),
+                            'C': (6.793435, pyunits.J*pyunits.mol**-1*pyunits.K**-1*pyunits.kiloK**-2),
+                            'D': (-2.534480, pyunits.J*pyunits.mol**-1*pyunits.K**-1*pyunits.kiloK**-3),
+                            'E': (0.082139, pyunits.J*pyunits.mol**-1*pyunits.K**-1*pyunits.kiloK**2),
+                            'F': (-250.8810, pyunits.kJ/pyunits.mol),
+                            'G': (223.3967, pyunits.J/pyunits.mol/pyunits.K),
+                            'H': (0, pyunits.kJ/pyunits.mol)},
+                        "entr_mol_form_liq_comp_ref": (69.95, pyunits.J/pyunits.K/pyunits.mol)
+                        # End parameter_data
+                        }},
+            'H_+': {"type": Cation, "charge": 1,
+                  # Define the methods used to calculate the following properties
+                  "dens_mol_liq_comp": Constant,
+                  "enth_mol_liq_comp": Constant,
+                  "cp_mol_liq_comp": Constant,
+                  "entr_mol_liq_comp": Constant,
+                  # Parameter data is always associated with the methods defined above
+                  "parameter_data": {
+                        "mw": (1.00784, pyunits.g/pyunits.mol),
+                        "dens_mol_liq_comp_coeff": (55, pyunits.kmol*pyunits.m**-3),
+                        "enth_mol_form_liq_comp_ref": (0, pyunits.kJ/pyunits.mol),
+                        "cp_mol_liq_comp_coeff": (75000, pyunits.J/pyunits.kmol/pyunits.K),
+                        "entr_mol_form_liq_comp_ref": (0, pyunits.J/pyunits.K/pyunits.mol)
+                                    },
+                        # End parameter_data
+                        },
+            'OH_-': {"type": Anion, "charge": -1,
+                  # Define the methods used to calculate the following properties
+                  "dens_mol_liq_comp": Constant,
+                  "enth_mol_liq_comp": Constant,
+                  "cp_mol_liq_comp": Constant,
+                  "entr_mol_liq_comp": Constant,
+                  # Parameter data is always associated with the methods defined above
+                  "parameter_data": {
+                        "mw": (17.008, pyunits.g/pyunits.mol),
+                        "dens_mol_liq_comp_coeff": (55, pyunits.kmol*pyunits.m**-3),
+                        "enth_mol_form_liq_comp_ref": (-230.000, pyunits.kJ/pyunits.mol),
+                        "cp_mol_liq_comp_coeff": (75000, pyunits.J/pyunits.kmol/pyunits.K),
+                        "entr_mol_form_liq_comp_ref": (-10.75, pyunits.J/pyunits.K/pyunits.mol)
+                                    },
+                        # End parameter_data
+                        }
+                  },
+                  # End Component list
+
+            "phases":  {'Liq': {"type": AqueousPhase,
+                                "equation_of_state": Ideal},
+                        },
+
+            "state_definition": FTPx,
+
+            # This is an optional dictionary to setup bounds on
+            #   the state variables. Names below MUST correspond
+            #   to the 'FTPx' type state definition
+            "state_bounds": {"flow_mol": (0, 50, 100),
+                             "temperature": (273.15, 300, 650),
+                             "pressure": (5e4, 1e5, 1e6)
+                         },
+
+            # These are generally optional parameters, however, because we
+            #   are using the Perry's model to calculate temperature dependent
+            #   properties, we MUST provide these here.
+            "pressure_ref": 1e5,
+            "temperature_ref": 300,
+
+            # Our dictionary for base units MUST define the following
+            "base_units": {"time": pyunits.s,
+                           "length": pyunits.m,
+                           "mass": pyunits.kg,
+                           "amount": pyunits.mol,
+                           "temperature": pyunits.K},
+
+             # Inherent reactions
+             #    These are added just like any other equilibrium reaction
+             #    would be defined in a reaction config
+             "inherent_reactions": {
+                 "H2O_Kw": {
+                         "stoichiometry": {("Liq", "H2O"): -1,
+                                          ("Liq", "H_+"): 1,
+                                          ("Liq", "OH_-"): 1},
+                        "heat_of_reaction": constant_dh_rxn,
+                        "equilibrium_constant": van_t_hoff,
+                        "equilibrium_form": log_power_law_equil,
+                        "concentration_form": ConcentrationForm.moleFraction,
+                        "parameter_data": {
+                            "dh_rxn_ref": (55.830, pyunits.J/pyunits.mol),
+                            "k_eq_ref": (10**-14/55.2/55.2, pyunits.dimensionless),
+                            "T_eq_ref": (298, pyunits.K),
+
+                            # By default, reaction orders follow stoichiometry
+                            #    manually set reaction order here to override
+                            "reaction_order": {("Liq", "H2O"): 0,
+                                             ("Liq", "H_+"): 1,
+                                             ("Liq", "OH_-"): 1}
+                             }
+                             # End parameter_data
+                        }
+                  }
+                  # End inherent reactions
+        }
+        # End thermo_config definition
+
+For a detailed analysis of everything from above, see
+:ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`.
+
+
+.. note::
+
+    Even if your system only involves inherent reactions, you may still be required to provide
+    a reaction configuration dictionary to construct certain unit models (such as EquilibriumReactor).
+    However, your reaction configuration may be a blank or a **dummy** config (see below)
+
+Example of a dummy **reaction_config**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. testcode::
+
+    # Importing the object for units from pyomo
+    from pyomo.environ import units as pyunits
+
+    # Import safe log power law equation
+    from idaes.generic_models.properties.core.reactions.equilibrium_forms import log_power_law_equil
+
+    # This config is REQUIRED to use EquilibriumReactor even if we have no equilibrium reactions
+    reaction_config = {
+        "base_units": {"time": pyunits.s,
+                       "length": pyunits.m,
+                       "mass": pyunits.kg,
+                       "amount": pyunits.mol,
+                       "temperature": pyunits.K},
+        "equilibrium_reactions": {
+            "dummy": {
+                    "stoichiometry": {},
+                    "equilibrium_form": log_power_law_equil,
+                   }
+                   # End reaction
+             }
+             # End equilibrium_reactions
+        }
+        # End reaction_config definition
+
+
+Example: Using our configuration dictionaries in an EquilibriumReactor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Recall, we had named our configuration dictionaries as ``thermo_config`` and
+``reaction_config``. We will reference those dictionary names in the example
+code below.
+
+.. testcode::
+
+    # Import specific pyomo objects
+    from pyomo.environ import ConcreteModel
+
+    # Import the core idaes objects for Flowsheets and types of balances
+    from idaes.core import FlowsheetBlock
+
+    # Import the idaes objects for Generic Properties and Reactions
+    from idaes.generic_models.properties.core.generic.generic_property import GenericParameterBlock
+    from idaes.generic_models.properties.core.generic.generic_reaction import GenericReactionParameterBlock
+
+    # Import the idaes object for the EquilibriumReactor unit model
+    from idaes.generic_models.unit_models.equilibrium_reactor import EquilibriumReactor
+
+    # Create an instance of a pyomo model
+    model = ConcreteModel()
+
+    # Add an IDAES flowsheet to that model
+    model.fs = FlowsheetBlock(default={"dynamic": False})
+
+    # Add a thermo parameter block to that flowsheet
+    #   Here, we are passing our 'thermo_config' dictionary we created earlier
+    model.fs.thermo_params = GenericParameterBlock(default=thermo_config)
+
+    # Add a reaction parameter block to that flowsheet
+    #   Here, we are passing our thermo block created above as the property package
+    #   and then giving our 'reaction_config' as the instructions for how the
+    #   reactions will be constructed from the thermo package.
+    model.fs.rxn_params = GenericReactionParameterBlock(
+                default={"property_package": model.fs.thermo_params, **reaction_config})
+
+    # Add an EquilibriumReactor object as the unit model
+    #   Here, we pass both the thermo package and reaction package, as well
+    #   as a number of other arguments to help define how this unit process
+    #   will behave.
+    #
+    # NOTE: What is different here is now we state that there are no
+    #       equilibrium reactions in this unit model because we defined
+    #       those reactions as inherent.
+    model.fs.unit = EquilibriumReactor(default={
+                "property_package": model.fs.thermo_params,
+                "reaction_package": model.fs.rxn_params,
+                "has_rate_reactions": False,
+                "has_equilibrium_reactions": False,
+                "has_heat_transfer": False,
+                "has_heat_of_reaction": False,
+                "has_pressure_change": False})
+
+    # At this point, you can 'fix' your inlet/outlet state conditions,
+    #     setup scaling factors, initialize the model, then solve the model
+    #     just as you would with any other IDAES flowsheet

--- a/docs/how_to_guides/how_to_use_inherent_reactions.rst
+++ b/docs/how_to_guides/how_to_use_inherent_reactions.rst
@@ -1,0 +1,31 @@
+.. _how_to_use_inherent_reactions:
+
+How to use inherent reactions
+=============================
+
+In :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`, we showed
+an example of setting up a **thermo_config** and **reaction_config** and put all
+reactions in that **reaction_config**. However, it is possible to place reactions
+into the **thermo_config** itself using **Inherent Reactions**. This guide will
+perform the same walk through and setup from :ref:`How to setup simple chemistry<how_to_setup_simple_chemistry>`,
+but will place reactions into the **thermo_config** itself.
+
+
+Inherent Reaction vs Other Reactions
+------------------------------------
+
+The **Inherent Reactions** are reactions that will be common to all unit processes
+within a flowsheet. Thus, it is convenient to put those common reactions into
+the **thermo_config** as inherent. Then, the non-inherent reactions in the **reaction_config**
+will be unique to a specific unit process.
+
+.. note::
+
+    It is possible to mix inherent reactions and non-inherent reactions within the
+    same unit process. However, user's need to take care and make sure that if a
+    reaction is in the **thermo_config** as inherent, then it SHOULD NOT also
+    show up in the **reaction_config**. This would create a degeneracy in the model.
+
+
+Example **thermo_config**
+^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/how_to_guides/index.rst
+++ b/docs/how_to_guides/index.rst
@@ -8,6 +8,7 @@ How To Guides
    how_to_setup_RO_config_options
    how_to_setup_simple_chemistry
    how_to_use_apparent_and_true_chemical_species
+   how_to_use_inherent_reactions
    how_to_scale_chemical_reactions
    how_to_scale_chemical_species
    how_to_scale_a_model

--- a/docs/how_to_guides/index.rst
+++ b/docs/how_to_guides/index.rst
@@ -9,9 +9,9 @@ How To Guides
    how_to_setup_simple_chemistry
    how_to_use_apparent_and_true_chemical_species
    how_to_use_inherent_reactions
+   how_to_scale_a_model
    how_to_scale_chemical_reactions
    how_to_scale_chemical_species
-   how_to_scale_a_model
    how_to_use_parameter_sweep
    how_to_use_EDB
    how_to_contribute_development

--- a/docs/how_to_guides/index.rst
+++ b/docs/how_to_guides/index.rst
@@ -8,6 +8,7 @@ How To Guides
    how_to_setup_RO_config_options
    how_to_setup_simple_chemistry
    how_to_use_apparent_and_true_chemical_species
+   how_to_scale_chemical_reactions
    how_to_scale_a_model
    how_to_use_parameter_sweep
    how_to_use_EDB

--- a/docs/how_to_guides/index.rst
+++ b/docs/how_to_guides/index.rst
@@ -9,6 +9,7 @@ How To Guides
    how_to_setup_simple_chemistry
    how_to_use_apparent_and_true_chemical_species
    how_to_scale_chemical_reactions
+   how_to_scale_chemical_species
    how_to_scale_a_model
    how_to_use_parameter_sweep
    how_to_use_EDB


### PR DESCRIPTION
## Fixes/Addresses:

#168 

## Summary/Motivation:

This PR adds documentation on scaling for chemical processes. Scaling of these models is a consistent and re-occurring issue, so these documents will be continuously updated as our scaling process changes. These docs represent the current scaling methods employed in our testing. I also updated the how to guide for basic chemistry modules to reflect our change over from molarity to molefraction in testing. 

## Changes proposed in this PR:
- Added how to for scaling reactions
- Added how to for scaling chemical species 
- Added how to for using inherent reactions
- Updated how to for basic chemistry 
- Updated indexing for how to guides 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
