### PR TITLE
Update remineralization test

### DIFF
--- a/proteuslib/tests/test_remineralization.py
+++ b/proteuslib/tests/test_remineralization.py
@@ -1445,7 +1445,7 @@ class TestRemineralizationCSTR():
         solver.options['bound_push'] = 1e-20
         solver.options['mu_init'] = 1e-6
         model.fs.unit.initialize(optarg=solver.options, outlvl=idaeslog.DEBUG)
-        assert degrees_of_freedom(model) == 1
+        assert degrees_of_freedom(model) == 0
 
     @pytest.mark.component
     def test_solve_cstr_kin(self, remineralization_cstr_kin):
@@ -1465,8 +1465,8 @@ class TestRemineralizationCSTR():
         pH = -value(log10(model.fs.unit.outlet.mole_frac_comp[0, "H_+"]*total_molar_density))
         pOH = -value(log10(model.fs.unit.outlet.mole_frac_comp[0, "OH_-"]*total_molar_density))
 
-        assert pytest.approx(8.1628836, rel=1e-4) == pH
-        assert pytest.approx(5.8382856, rel=1e-4) == pOH
+        assert pytest.approx(8.1593619, rel=1e-4) == pH
+        assert pytest.approx(5.8412514, rel=1e-4) == pOH
 
         # Calculate total hardness
         TH = 2*value(model.fs.unit.control_volume.properties_out[0.0].conc_mol_phase_comp[('Liq', 'Ca_2+')])/1000

--- a/proteuslib/tests/test_remineralization.py
+++ b/proteuslib/tests/test_remineralization.py
@@ -1154,13 +1154,13 @@ thermo_config_cstr = {
                                      ("Liq", "H_+"): 1,
                                      ("Liq", "OH_-"): 1},
                    "heat_of_reaction": constant_dh_rxn,
-                   "equilibrium_constant": gibbs_energy,
+                   "equilibrium_constant": van_t_hoff,
                    "equilibrium_form": log_power_law_equil,
-                   "concentration_form": ConcentrationForm.molarity,
+                   "concentration_form": ConcentrationForm.moleFraction,
                    "parameter_data": {
-                       "dh_rxn_ref": (55.830, pyunits.kJ/pyunits.mol),
-                       "ds_rxn_ref": (-80.7, pyunits.J/pyunits.mol/pyunits.K),
-                       "T_eq_ref": (300, pyunits.K),
+                       "dh_rxn_ref": (55.830, pyunits.J/pyunits.mol),
+                       "k_eq_ref": (10**-14/55.2/55.2, pyunits.dimensionless),
+                       "T_eq_ref": (298, pyunits.K),
 
                        # By default, reaction orders follow stoichiometry
                        #    manually set reaction order here to override
@@ -1176,13 +1176,13 @@ thermo_config_cstr = {
                                      ("Liq", "H_+"): 1,
                                      ("Liq", "HCO3_-"): 1},
                    "heat_of_reaction": constant_dh_rxn,
-                   "equilibrium_constant": gibbs_energy,
+                   "equilibrium_constant": van_t_hoff,
                    "equilibrium_form": log_power_law_equil,
-                   "concentration_form": ConcentrationForm.molarity,
+                   "concentration_form": ConcentrationForm.moleFraction,
                    "parameter_data": {
                        "dh_rxn_ref": (7.7, pyunits.kJ/pyunits.mol),
-                       "ds_rxn_ref": (-95.8, pyunits.J/pyunits.mol/pyunits.K),
-                       "T_eq_ref": (300, pyunits.K),
+                       "k_eq_ref": (10**-6.35/55.2, pyunits.dimensionless),
+                       "T_eq_ref": (298, pyunits.K),
 
                        # By default, reaction orders follow stoichiometry
                        #    manually set reaction order here to override
@@ -1198,13 +1198,13 @@ thermo_config_cstr = {
                                      ("Liq", "H_+"): 1,
                                      ("Liq", "CO3_2-"): 1},
                    "heat_of_reaction": constant_dh_rxn,
-                   "equilibrium_constant": gibbs_energy,
+                   "equilibrium_constant": van_t_hoff,
                    "equilibrium_form": log_power_law_equil,
-                   "concentration_form": ConcentrationForm.molarity,
+                   "concentration_form": ConcentrationForm.moleFraction,
                    "parameter_data": {
                        "dh_rxn_ref": (14.9, pyunits.kJ/pyunits.mol),
-                       "ds_rxn_ref": (-148.1, pyunits.J/pyunits.mol/pyunits.K),
-                       "T_eq_ref": (300, pyunits.K),
+                       "k_eq_ref": (10**-10.33/55.2, pyunits.dimensionless),
+                       "T_eq_ref": (298, pyunits.K),
 
                        # By default, reaction orders follow stoichiometry
                        #    manually set reaction order here to override
@@ -1222,11 +1222,11 @@ thermo_config_cstr = {
                    "heat_of_reaction": constant_dh_rxn,
                    "equilibrium_constant": van_t_hoff,
                    "equilibrium_form": log_power_law_equil,
-                   "concentration_form": ConcentrationForm.molarity,
+                   "concentration_form": ConcentrationForm.moleFraction,
                    "parameter_data": {
-                       "dh_rxn_ref": (0, pyunits.kJ/pyunits.mol),
-                       "k_eq_ref": (1.7*10**-3,None),
-                       "T_eq_ref": (300, pyunits.K),
+                       "dh_rxn_ref": (0, pyunits.kJ / pyunits.mol),
+                       "k_eq_ref": (1.7*10**-3, pyunits.dimensionless),
+                       "T_eq_ref": (298, pyunits.K),
 
                        # By default, reaction orders follow stoichiometry
                        #    manually set reaction order here to override
@@ -1445,7 +1445,7 @@ class TestRemineralizationCSTR():
         solver.options['bound_push'] = 1e-20
         solver.options['mu_init'] = 1e-6
         model.fs.unit.initialize(optarg=solver.options, outlvl=idaeslog.DEBUG)
-        assert degrees_of_freedom(model) == 0
+        assert degrees_of_freedom(model) == 1
 
     @pytest.mark.component
     def test_solve_cstr_kin(self, remineralization_cstr_kin):


### PR DESCRIPTION
## Fixes/Addresses:

This update is to change over the molarity basis to a molefraction basis for the CSTR test. This was missed when last updating the tests and is being updated to reflect most recent standards for the chemistry modules. 

## Summary/Motivation:

Correction of chemistry module that was missed in prior update of chem tests. 

## Changes proposed in this PR:
- Changed CSTR to use all molefraction basis for reactions
- Updated the pH and pOH values slightly to reflect these calculations on a molefraction basis

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
