### PR TITLE
Enable MongoDB in CI checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,7 +70,7 @@ jobs:
         idaes get-extensions --verbose
         echo '::endgroup::'
     - name: Set up MongoDB server
-      if: 'false'
+      if: matrix.mongodb_server
       uses: supercharge/mongodb-github-action@3f91157600649d0002802978c8b6fb6ee659a2dd
       # with:
         # everything else being equal, we test against 4.03 since it's the latest available
@@ -83,7 +83,7 @@ jobs:
         _pytest_output_to_inspect: .pytest-edb-mongodb.log
       run: |
         # load EDB
-        # edb load -b
+        edb load -b
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
         echo '::group::pytest output to be inspected for skipped files'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,7 +82,8 @@ jobs:
       if: matrix.mongodb_server
       run: |
         # TODO it would be better to use a command that fails if tests are skipped
-        pytest -k 'db_api' -v
+        pytest -k 'db_api' -sv
+        pytest -k 'edb' -sv
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,7 +70,7 @@ jobs:
         idaes get-extensions --verbose
         echo '::endgroup::'
     - name: Set up MongoDB server
-      if: matrix.mongodb_server
+      if: 'false'
       uses: supercharge/mongodb-github-action@3f91157600649d0002802978c8b6fb6ee659a2dd
       # with:
         # everything else being equal, we test against 4.03 since it's the latest available
@@ -83,7 +83,7 @@ jobs:
         _pytest_output_to_inspect: .pytest-edb-mongodb.log
       run: |
         # load EDB
-        edb load -b
+        # edb load -b
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
         cat "$_pytest_output_to_inspect"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,7 +87,7 @@ jobs:
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
         # "reverse grep": the overall command fails unless no match was found (exit code 1)
-        grep "SKIPPED" "$_pytest_output_to_inspect" ; test $? -eq 1
+        grep "SKIPPED" "$_pytest_output_to_inspect"
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,6 +87,7 @@ jobs:
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
         cat "$_pytest_output_to_inspect"
+        bash -c 'grep "SKIPPED" "$_pytest_output_to_inspect" ; test $? -eq 1'
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,12 +78,16 @@ jobs:
         # mongodb-version: "4.03"
     - name: Test connection to MongoDB instance
       if: matrix.mongodb_server
+      env:
+        _tests_that_should_not_be_skipped: db_api
+        _pytest_output_to_inspect: .pytest-edb-mongodb.log
       run: |
         # load EDB
         edb load -b
-        # TODO it would be better to use a command that fails if tests are skipped
-        pytest -k 'db_api' -sv
-        pytest -k 'edb' -sv
+        # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
+        pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
+        # "reverse grep": the overall command fails unless no match was found (exit code 1)
+        grep "SKIPPED" "$_pytest_output_to_inspect" ; test $? -eq 1
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,9 @@ jobs:
           - python-version: '3.8'
             # limit uploading coverage report for a single Python version in the matrix
             cov_report: true
+          - python-version: '3.8'
+            os: linux
+            # supercharge/mongodb-github-action is a container action, that's only available for Linux
             mongodb_server: true
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,6 @@ jobs:
   tests:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os-version }}
-    if: matrix.mongodb_server  # FIXME remove after debugging
     strategy:
       fail-fast: false
       matrix:
@@ -45,12 +44,15 @@ jobs:
             mongodb_server: true
     steps:
     - uses: actions/checkout@v2
+      if: matrix.mongodb_server  # FIXME remove after debugging
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
+      if: matrix.mongodb_server  # FIXME remove after debugging
       with:
         activate-environment: proteuslib-dev
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      if: matrix.mongodb_server  # FIXME remove after debugging
       run: |
         echo '::group::Output of "conda install" commands'
         conda install --quiet --yes pip=21.1 wheel setuptools
@@ -82,17 +84,20 @@ jobs:
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV
     - name: Test with pytest
+      if: matrix.mongodb_server  # FIXME remove after debugging
       run: |
         pytest
     - name: Upload coverage report to Codecov
       if: matrix.cov_report
       uses: codecov/codecov-action@v2
     - name: Test documentation code
+      if: "false"  # FIXME remove after debugging
       run: |
         make -C docs doctest -d
     # just run the linkcheck on one of the jobs
     # so we don't slam external sites
     - name: Test documentation links
-      if: matrix.python-version == 3.9 && matrix.os == 'linux'
+      if: "false"
+      # if: matrix.python-version == 3.9 && matrix.os == 'linux'
       run: |
         make -C docs linkcheck -d

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,21 +41,19 @@ jobs:
           - python-version: '3.8'
             # limit uploading coverage report for a single Python version in the matrix
             cov_report: true
-          - python-version: '3.8'
-            os: linux
+            # same for link-checking in the HTML docs so we don't slam external sites
+            check_docs_links: true
+          - os: linux
             # supercharge/mongodb-github-action is a container action, that's only available for Linux
             mongodb_server: true
     steps:
     - uses: actions/checkout@v2
-      if: matrix.mongodb_server  # FIXME remove after debugging
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
-      if: matrix.mongodb_server  # FIXME remove after debugging
       with:
         activate-environment: proteuslib-dev
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      if: matrix.mongodb_server  # FIXME remove after debugging
       run: |
         echo '::group::Output of "conda install" commands'
         conda install --quiet --yes pip=21.1 wheel setuptools
@@ -90,20 +88,17 @@ jobs:
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV
     - name: Test with pytest
-      if: matrix.mongodb_server  # FIXME remove after debugging
       run: |
         pytest
     - name: Upload coverage report to Codecov
       if: matrix.cov_report
       uses: codecov/codecov-action@v2
     - name: Test documentation code
-      if: "false"  # FIXME remove after debugging
       run: |
         make -C docs doctest -d
     # just run the linkcheck on one of the jobs
     # so we don't slam external sites
     - name: Test documentation links
-      if: "false"
-      # if: matrix.python-version == 3.9 && matrix.os == 'linux'
+      if: matrix.check_docs_links
       run: |
         make -C docs linkcheck -d

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,6 +81,8 @@ jobs:
     - name: Test connection to MongoDB instance
       if: matrix.mongodb_server
       run: |
+        # load EDB
+        edb load -b
         # TODO it would be better to use a command that fails if tests are skipped
         pytest -k 'db_api' -sv
         pytest -k 'edb' -sv

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,8 +86,7 @@ jobs:
         edb load -b
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
-        # "reverse grep": the overall command fails unless no match was found (exit code 1)
-        grep "SKIPPED" "$_pytest_output_to_inspect"
+        cat "$_pytest_output_to_inspect"
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,10 +68,10 @@ jobs:
     - name: Set up MongoDB server
       if: matrix.mongodb_server
       uses: supercharge/mongodb-github-action@3f91157600649d0002802978c8b6fb6ee659a2dd
-      with:
+      # with:
         # everything else being equal, we test against 4.03 since it's the latest available
         # through Conda, which makes installation significantly easier for users
-        mongodb-version: "4.03"
+        # mongodb-version: "4.03"
     - name: Test connection to MongoDB instance
       if: matrix.mongodb_server
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,8 +86,12 @@ jobs:
         # edb load -b
         # run subset of tests that should not be skipped if the MongoDB instance is accessible to the EDB
         pytest -k "$_tests_that_should_not_be_skipped" --verbose --capture=tee-sys | tee "$_pytest_output_to_inspect"
+        echo '::group::pytest output to be inspected for skipped files'
         cat "$_pytest_output_to_inspect"
+        echo '::endgroup::'
+        echo '::group::output of grep searching for skipped tests in pytest output'
         bash -c 'grep "SKIPPED" "$_pytest_output_to_inspect" ; test $? -eq 1'
+        echo '::endgroup::'
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,7 @@ jobs:
   tests:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os-version }}
+    if: matrix.mongodb_server  # FIXME remove after debugging
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,9 +38,10 @@ jobs:
             os-version: windows-2019
           # - os: macos
           #   os-version: macos-10.15
-          # limit uploading coverage report for a single Python version in the matrix
           - python-version: '3.8'
+            # limit uploading coverage report for a single Python version in the matrix
             cov_report: true
+            mongodb_server: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -64,6 +65,18 @@ jobs:
         echo '::group::Output of "idaes get-extensions" command'
         idaes get-extensions --verbose
         echo '::endgroup::'
+    - name: Set up MongoDB server
+      if: matrix.mongodb_server
+      uses: supercharge/mongodb-github-action@3f91157600649d0002802978c8b6fb6ee659a2dd
+      with:
+        # everything else being equal, we test against 4.03 since it's the latest available
+        # through Conda, which makes installation significantly easier for users
+        mongodb-version: "4.03"
+    - name: Test connection to MongoDB instance
+      if: matrix.mongodb_server
+      run: |
+        # TODO it would be better to use a command that fails if tests are skipped
+        pytest -k 'db_api' -v
     - name: Add coverage report options
       if: matrix.cov_report
       run: echo 'PYTEST_ADDOPTS="--cov-report=xml"' >> $GITHUB_ENV

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,8 @@ jobs:
           - python-version: '3.8'
             # limit uploading coverage report for a single Python version in the matrix
             cov_report: true
+          - python-version: '3.9'
+            os: linux
             # same for link-checking in the HTML docs so we don't slam external sites
             check_docs_links: true
           - os: linux


### PR DESCRIPTION
## Fixes/Addresses: #207

## Changes proposed in this PR:
- Enable MongoDB in GitHub Actions through 3rd-party Action (https://github.com/supercharge/mongodb-github-action)
- Add dedicated "pre-test" to ensure MongoDB is reachable by the Proteuslib test suite before running the complete set of tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
