### PR TITLE
Address KeyError in os.environ when testing locally (#217)

### DIFF
--- a/proteuslib/tests/test_pure_water_pH_edb.py
+++ b/proteuslib/tests/test_pure_water_pH_edb.py
@@ -26,7 +26,7 @@ from .test_pure_water_pH import TestPureWater
 g_edb = None
 if ElectrolyteDB.can_connect():
     # for now, skip using MongoDB in GitHub CI -dang 8/30/2021
-    if os.environ['GITHUB_ACTIONS'] != "true":
+    if os.environ.get('GITHUB_ACTIONS') != "true":
         g_edb = ElectrolyteDB()
 
 


### PR DESCRIPTION
## Fixes/Addresses: #217

## Changes proposed in this PR:
- Use `get()` instead of `__getitem__()` for `os.environ` to account for env var not being set when running tests locally

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
