### PR TITLE
Repair enth_mass coeffs

### DIFF
--- a/watertap/flowsheets/MD/tests/test_MD.py
+++ b/watertap/flowsheets/MD/tests/test_MD.py
@@ -131,9 +131,9 @@ class TestMDContinuousRecirculation:
             m.fs.permeate.flow_mass_phase_comp[0, "Liq", "TDS"]
         )
         assert pytest.approx(0.5, rel=1e-5) == value(m.fs.overall_recovery)
-        assert pytest.approx(6.169, rel=1e-3) == value(m.fs.recycle_ratio[0])
-        assert pytest.approx(15.44, rel=1e-3) == value(m.fs.costing.LCOW)
-        assert pytest.approx(182.9, rel=1e-3) == value(
+        assert pytest.approx(5.289, rel=1e-3) == value(m.fs.recycle_ratio[0])
+        assert pytest.approx(12.79, rel=1e-3) == value(m.fs.costing.LCOW)
+        assert pytest.approx(142.66, rel=1e-3) == value(
             m.fs.costing.specific_energy_consumption
         )
 

--- a/watertap/flowsheets/mvc/mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/mvc_single_stage.py
@@ -262,8 +262,8 @@ def build():
     iscale.set_scaling_factor(m.fs.pump_distillate.control_volume.work, 1e-3)
 
     # distillate HX
-    iscale.set_scaling_factor(m.fs.hx_distillate.hot.heat, 1e-3)
-    iscale.set_scaling_factor(m.fs.hx_distillate.cold.heat, 1e-3)
+    iscale.set_scaling_factor(m.fs.hx_distillate.hot.heat, 1e-6)
+    iscale.set_scaling_factor(m.fs.hx_distillate.cold.heat, 1e-6)
     iscale.set_scaling_factor(
         m.fs.hx_distillate.overall_heat_transfer_coefficient, 1e-3
     )

--- a/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
+++ b/watertap/flowsheets/mvc/tests/test_mvc_single_stage.py
@@ -326,14 +326,14 @@ class TestMVC:
             32448.24, rel=1e-2
         )
         assert value(m.fs.hx_brine.area) == pytest.approx(173.99, rel=1e-2)
-        assert value(m.fs.hx_distillate.area) == pytest.approx(206.31, rel=1e-2)
+        assert value(m.fs.hx_distillate.area) == pytest.approx(199.229, rel=1e-2)
         assert value(m.fs.compressor.pressure_ratio) == pytest.approx(1.61, rel=1e-2)
-        assert value(m.fs.evaporator.area) == pytest.approx(777.37, rel=1e-2)
-        assert value(m.fs.evaporator.lmtd) == pytest.approx(22.59, rel=1e-2)
+        assert value(m.fs.evaporator.area) == pytest.approx(789.135, rel=1e-2)
+        assert value(m.fs.evaporator.lmtd) == pytest.approx(22.247, rel=1e-2)
 
         # Check system metrics
         assert value(m.fs.costing.specific_energy_consumption) == pytest.approx(
-            22.36, rel=1e-2
+            22.12, rel=1e-2
         )
         assert value(m.fs.costing.LCOW) == pytest.approx(4.52, rel=1e-2)
 

--- a/watertap/property_models/multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/multicomp_aq_sol_prop_pack.py
@@ -2356,7 +2356,7 @@ class MCASStateBlockData(StateBlockData):
             )
             params.enth_mass_param_B6 = Var(
                 within=Reals,
-                initialize=-4.41733,
+                initialize=-4.41733e1,
                 units=enth_mass_units * t_inv_units**2,
                 doc="Specific enthalpy parameter B6",
             )
@@ -2380,7 +2380,7 @@ class MCASStateBlockData(StateBlockData):
             )
             params.enth_mass_param_B10 = Var(
                 within=Reals,
-                initialize=9.72801,
+                initialize=9.72801e1,
                 units=enth_mass_units * t_inv_units**2,
                 doc="Specific enthalpy parameter B10",
             )

--- a/watertap/property_models/seawater_prop_pack.py
+++ b/watertap/property_models/seawater_prop_pack.py
@@ -418,7 +418,7 @@ class SeawaterParameterData(PhysicalParameterBlock):
         )
         self.enth_mass_param_B6 = Var(
             within=Reals,
-            initialize=-4.41733,
+            initialize=-4.41733e1,
             units=enth_mass_units * t_inv_units**2,
             doc="Specific enthalpy parameter B6",
         )
@@ -442,7 +442,7 @@ class SeawaterParameterData(PhysicalParameterBlock):
         )
         self.enth_mass_param_B10 = Var(
             within=Reals,
-            initialize=9.72801,
+            initialize=9.72801e1,
             units=enth_mass_units * t_inv_units**2,
             doc="Specific enthalpy parameter B10",
         )

--- a/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
@@ -41,6 +41,7 @@ from idaes.core.util.model_statistics import (
     number_variables,
     number_total_constraints,
     number_unused_variables,
+    degrees_of_freedom,
 )
 from idaes.core.util.scaling import (
     unscaled_variables_generator,
@@ -2610,6 +2611,244 @@ def test_automatic_charge_mw_population():
     for comp, val in test_vals.items():
         assert value(m.fs.stream2[0].mw_comp[comp]) == val[0]
         assert value(m.fs.stream2[0].charge_comp[comp]) == val[1]
+
+
+# Enthalpy (kJ/kg), density (g/L), and vapor pressure (kPa) data from
+# https://web.mit.edu/seawater/2017_MIT_Seawater_Property_Tables_r2b_2023c.pdf
+enth_dens_pres_sat_data = {
+    (10, 10): {
+        "dens_mass_phase": 1007.4,
+        "enth_mass_phase": 41.6,
+        "pressure_sat": 1.222,
+    },
+    (10, 30): {
+        "dens_mass_phase": 1023.0,
+        "enth_mass_phase": 40.4,
+        "pressure_sat": 1.209,
+    },
+    (10, 50): {
+        "dens_mass_phase": 1038.7,
+        "enth_mass_phase": 39.0,
+        "pressure_sat": 1.194,
+    },
+    (10, 70): {
+        "dens_mass_phase": 1054.4,
+        "enth_mass_phase": 37.2,
+        "pressure_sat": 1.177,
+    },
+    (10, 90): {
+        "dens_mass_phase": 1070.1,
+        "enth_mass_phase": 35.2,
+        "pressure_sat": 1.159,
+    },
+    (10, 120): {
+        "dens_mass_phase": 1093.6,
+        "enth_mass_phase": 31.9,
+        "pressure_sat": 1.129,
+    },
+    (30, 10): {
+        "dens_mass_phase": 1003.1,
+        "enth_mass_phase": 124.1,
+        "pressure_sat": 4.226,
+    },
+    (30, 30): {
+        "dens_mass_phase": 1018.2,
+        "enth_mass_phase": 120.6,
+        "pressure_sat": 4.18,
+    },
+    (30, 50): {
+        "dens_mass_phase": 1033.4,
+        "enth_mass_phase": 117.1,
+        "pressure_sat": 4.129,
+    },
+    (30, 70): {
+        "dens_mass_phase": 1048.5,
+        "enth_mass_phase": 113.5,
+        "pressure_sat": 4.071,
+    },
+    (30, 90): {
+        "dens_mass_phase": 1063.6,
+        "enth_mass_phase": 109.7,
+        "pressure_sat": 4.008,
+    },
+    (30, 120): {
+        "dens_mass_phase": 1086.3,
+        "enth_mass_phase": 104.1,
+        "pressure_sat": 3.902,
+    },
+    (50, 10): {
+        "dens_mass_phase": 995.5,
+        "enth_mass_phase": 206.6,
+        "pressure_sat": 12.291,
+    },
+    (50, 30): {
+        "dens_mass_phase": 1010.3,
+        "enth_mass_phase": 201.2,
+        "pressure_sat": 12.159,
+    },
+    (50, 50): {
+        "dens_mass_phase": 1025.1,
+        "enth_mass_phase": 195.9,
+        "pressure_sat": 12.009,
+    },
+    (50, 70): {
+        "dens_mass_phase": 1039.9,
+        "enth_mass_phase": 190.6,
+        "pressure_sat": 11.841,
+    },
+    (50, 90): {
+        "dens_mass_phase": 1054.7,
+        "enth_mass_phase": 185.3,
+        "pressure_sat": 11.656,
+    },
+    (50, 120): {
+        "dens_mass_phase": 1076.9,
+        "enth_mass_phase": 177.4,
+        "pressure_sat": 11.35,
+    },
+    (70, 10): {
+        "dens_mass_phase": 985.1,
+        "enth_mass_phase": 289.3,
+        "pressure_sat": 31.049,
+    },
+    (70, 30): {
+        "dens_mass_phase": 999.8,
+        "enth_mass_phase": 282.0,
+        "pressure_sat": 30.715,
+    },
+    (70, 50): {
+        "dens_mass_phase": 1014.5,
+        "enth_mass_phase": 275.0,
+        "pressure_sat": 30.336,
+    },
+    (70, 70): {
+        "dens_mass_phase": 1029.1,
+        "enth_mass_phase": 268.0,
+        "pressure_sat": 29.912,
+    },
+    (70, 90): {
+        "dens_mass_phase": 1043.8,
+        "enth_mass_phase": 261.1,
+        "pressure_sat": 29.446,
+    },
+    (70, 120): {
+        "dens_mass_phase": 1065.8,
+        "enth_mass_phase": 250.7,
+        "pressure_sat": 28.672,
+    },
+    (90, 10): {
+        "dens_mass_phase": 972.6,
+        "enth_mass_phase": 372.2,
+        "pressure_sat": 69.845,
+    },
+    (90, 30): {
+        "dens_mass_phase": 987.3,
+        "enth_mass_phase": 363.0,
+        "pressure_sat": 69.095,
+    },
+    (90, 50): {
+        "dens_mass_phase": 1002.0,
+        "enth_mass_phase": 354.1,
+        "pressure_sat": 68.241,
+    },
+    (90, 70): {
+        "dens_mass_phase": 1016.8,
+        "enth_mass_phase": 345.3,
+        "pressure_sat": 67.287,
+    },
+    (90, 90): {
+        "dens_mass_phase": 1031.5,
+        "enth_mass_phase": 336.5,
+        "pressure_sat": 66.239,
+    },
+    (90, 120): {
+        "dens_mass_phase": 1053.5,
+        "enth_mass_phase": 323.2,
+        "pressure_sat": 64.499,
+    },
+    (120, 10): {
+        "dens_mass_phase": 950.6,
+        "enth_mass_phase": 497.2,
+        "pressure_sat": 197.736,
+    },
+    (120, 30): {
+        "dens_mass_phase": 965.6,
+        "enth_mass_phase": 484.6,
+        "pressure_sat": 195.613,
+    },
+    (120, 50): {
+        "dens_mass_phase": 980.6,
+        "enth_mass_phase": 472.1,
+        "pressure_sat": 193.195,
+    },
+    (120, 70): {
+        "dens_mass_phase": 995.6,
+        "enth_mass_phase": 459.7,
+        "pressure_sat": 190.496,
+    },
+    (120, 90): {
+        "dens_mass_phase": 1010.6,
+        "enth_mass_phase": 447.1,
+        "pressure_sat": 187.528,
+    },
+    (120, 120): {
+        "dens_mass_phase": 1033.1,
+        "enth_mass_phase": 427.8,
+        "pressure_sat": 182.601,
+    },
+}
+
+temps = [10, 30, 50, 70, 90, 120]
+mass_fracs = [10, 30, 50, 70, 90, 120]
+
+
+@pytest.mark.parametrize("temperature", temps)
+@pytest.mark.parametrize("mass_frac", mass_fracs)
+@pytest.mark.component
+def test_enthalpy_density_pressure_sat_against_sw_data(temperature, mass_frac):
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.properties = MCASParameterBlock(
+        solute_list=["TDS"],
+        mw_data={"H2O": 0.018, "TDS": 0.01},
+        charge={"TDS": 0},
+        ignore_neutral_charge=True,
+        material_flow_basis=MaterialFlowBasis.mass,
+        density_calculation=DensityCalculation.seawater,
+    )
+    m.fs.stream = m.fs.properties.build_state_block([0], defined_state=True)
+
+    m.fs.properties.set_default_scaling("flow_mass_phase_comp", 1, index=("Liq", "H2O"))
+    m.fs.properties.set_default_scaling(
+        "flow_mass_phase_comp", 10, index=("Liq", "TDS")
+    )
+
+    m.fs.stream[0].flow_vol_phase
+    m.fs.stream[0].dens_mass_phase
+    m.fs.stream[0].enth_mass_phase
+    m.fs.stream[0].pressure_sat
+
+    calculate_scaling_factors(m)
+    var_args = {
+        ("flow_vol_phase", "Liq"): 1 * pyunits.liter / pyunits.second,
+        ("mass_frac_phase_comp", ("Liq", "TDS")): mass_frac / 1000,
+        ("temperature", None): 273.15 + temperature,
+        ("pressure", None): 1 * pyunits.bar,
+    }
+    m.fs.stream.calculate_state(var_args, hold_state=True)
+    assert degrees_of_freedom(m) == 0
+    results = solver.solve(m, tee=False)
+    assert_optimal_termination(results)
+
+    assert value(m.fs.stream[0].dens_mass_phase["Liq"]) == pytest.approx(
+        enth_dens_pres_sat_data[(temperature, mass_frac)]["dens_mass_phase"], rel=1e-3
+    )
+    assert value(m.fs.stream[0].enth_mass_phase["Liq"]) * 1e-3 == pytest.approx(
+        enth_dens_pres_sat_data[(temperature, mass_frac)]["enth_mass_phase"], rel=5e-3
+    )
+    assert value(m.fs.stream[0].pressure_sat) * 1e-3 == pytest.approx(
+        enth_dens_pres_sat_data[(temperature, mass_frac)]["pressure_sat"], rel=1e-3
+    )
 
 
 class TestMCASInitializer:

--- a/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
+++ b/watertap/property_models/tests/test_multicomp_aq_sol_prop_pack.py
@@ -857,8 +857,8 @@ def test_seawater_data():
         )
     )
     assert value(stream[0].total_dissolved_solids) == pytest.approx(35974.42, rel=1e-3)
-    assert value(stream[0].enth_mass_phase["Liq"]) == pytest.approx(98938.56, rel=1e-3)
-    assert value(stream[0].enth_flow) == pytest.approx(98918.931, rel=1e-3)
+    assert value(stream[0].enth_mass_phase["Liq"]) == pytest.approx(99744.185, rel=1e-3)
+    assert value(stream[0].enth_flow) == pytest.approx(99724.40, rel=1e-3)
     assert value(stream[0].pressure_sat) == pytest.approx(3110.73, rel=1e-3)
 
 

--- a/watertap/property_models/tests/test_seawater_prop_pack.py
+++ b/watertap/property_models/tests/test_seawater_prop_pack.py
@@ -23,7 +23,6 @@ from watertap.property_models.tests.property_test_harness import (
 )
 
 
-# -----------------------------------------------------------------------------
 class TestSeawaterProperty_idaes(PropertyTestHarness_idaes):
     def configure(self):
         self.prop_pack = props.SeawaterParameterBlock
@@ -161,6 +160,290 @@ class TestSeawaterPropertySolution_2(PropertyRegressionTest):
             ("dh_vap_mass", None): 2.353e6,
             ("diffus_phase_comp", ("Liq", "TDS")): 1.471e-9,
             ("boiling_point_elevation_phase", "Liq"): 0.4069,
+        }
+
+
+# Parameter values from:
+# https://web.mit.edu/seawater/2017_MIT_Seawater_Property_Tables_r2b_2023c.pdf
+# T = 10C, salinity = 10 g/kg, Q = 1 L/s
+@pytest.mark.component
+class TestSeawaterPropertyTemp10Salinity10(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.9972722,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.010073,
+            ("temperature", None): 273.15 + 10,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.99,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.01,
+            ("dens_mass_phase", "Liq"): 1007.3457,
+            ("dens_mass_solvent", None): 999.50934,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 997.27225,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 10.07345,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 55.35702,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 0.32077,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.99423,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.00576,
+            ("molality_phase_comp", ("Liq", "TDS")): 0.32164,
+            ("visc_d_phase", "Liq"): 0.00132956,  # 0.0133 Pa-s
+            ("osm_coeff", None): 0.89768,
+            ("pressure_osm_phase", "Liq"): 679429.93808,  # 0.679 MPa
+            ("enth_mass_phase", "Liq"): 41590.0253,  # 41.6 kJ/kg
+            ("energy_density_phase", "Liq"): 41795533.49664,
+            ("pressure_sat", None): 1222.13185,  # 1.222 kPa
+            ("cp_mass_phase", "Liq"): 4136.70887,  # 4136.7 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.58768,  # 0.588 W/m-K
+            ("dh_vap_mass", None): 2452555.1844,  # 2452.5 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.492e-09,
+            ("boiling_point_elevation_phase", "Liq"): 0.07309,  # 0.073 K
+        }
+
+
+# T = 30C, salinity = 30 g/kg, Q = 1 L/s
+@pytest.mark.component
+class TestSeawaterPropertyTemp30Salinity30(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.987677512,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.030546727,
+            ("temperature", None): 273.15 + 30,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.97,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.03,
+            ("dens_mass_phase", "Liq"): 1018.22423,
+            ("dens_mass_solvent", None): 995.53714,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 987.67751,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 30.54672,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 54.82443,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 0.9727,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.98256,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.01743,
+            ("molality_phase_comp", ("Liq", "TDS")): 0.98484,
+            ("visc_d_phase", "Liq"): 0.00085086,  # 0.000851 Pa-s
+            ("osm_coeff", None): 0.90569,
+            ("pressure_osm_phase", "Liq"): 2238198.31526,  # 2.238 MPa
+            ("enth_mass_phase", "Liq"): 120597.84791,  # 120.6 kJ/kg
+            ("energy_density_phase", "Liq"): 122695651.94676,
+            ("pressure_sat", None): 4180.36772,  # 4.180 kPa
+            ("cp_mass_phase", "Liq"): 4027.48595,  # 4027.5 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.61563,  # 0.616 W/m-K
+            ("dh_vap_mass", None): 2357037.33712,  # 2356.9 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.473e-09,
+            ("boiling_point_elevation_phase", "Liq"): 0.27175,  # 0.272 K
+        }
+
+
+# T = 50C, salinity = 50 g/kg, Q = 1 L/s
+@pytest.mark.component
+class TestSeawaterPropertyTemp50Salinity50(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.973797107,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.051252479,
+            ("temperature", None): 273.15 + 50,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.95,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.05,
+            ("dens_mass_phase", "Liq"): 1025.04958,
+            ("dens_mass_solvent", None): 988.04718,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 973.7971,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 51.25247,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 54.05395,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 1.63204,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.97069,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.0293,
+            ("molality_phase_comp", ("Liq", "TDS")): 1.67596,
+            ("visc_d_phase", "Liq"): 0.00061694,  # 0.000617 Pa-s
+            ("osm_coeff", None): 0.91724,
+            ("pressure_osm_phase", "Liq"): 4080987.77845,  # 4.081 MPa
+            ("enth_mass_phase", "Liq"): 195859.02578,  # 195.9 kJ/kg
+            ("energy_density_phase", "Liq"): 200665213.4249,
+            ("pressure_sat", None): 12008.61958,  # 12.009 kPa
+            ("cp_mass_phase", "Liq"): 3940.51113,  # 3940.5 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.63805,  # 0.638 W/m-K
+            ("dh_vap_mass", None): 2262972.85312,  # 2262.9 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.47e-09,
+            ("boiling_point_elevation_phase", "Liq"): 0.55617,  # 0.556 K
+        }
+
+
+# T = 70C, salinity = 70 g/kg, Q = 1 L/s
+@pytest.mark.component
+class TestSeawaterPropertyTemp70Salinity70(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.95708085,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.07203834,
+            ("temperature", None): 273.15 + 70,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.93,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.07,
+            ("dens_mass_phase", "Liq"): 1029.1192,
+            ("dens_mass_solvent", None): 977.76708,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 957.08085,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 72.03834,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 53.12606,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 2.29393,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.9586,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.04139,
+            ("molality_phase_comp", ("Liq", "TDS")): 2.3968,
+            ("visc_d_phase", "Liq"): 0.00048369,  # 0.000484 Pa-s
+            ("osm_coeff", None): 0.93293,
+            ("pressure_osm_phase", "Liq"): 6237901.49812,  # 6.238 MPa
+            ("enth_mass_phase", "Liq"): 268014.57187,  # 268.0 kJ/kg
+            ("energy_density_phase", "Liq"): 275718942.07197,
+            ("pressure_sat", None): 29912.03673,  # 29.912 kPa
+            ("cp_mass_phase", "Liq"): 3862.34273,  # 3862.4 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.65529,  # 0.655 W/m-K
+            ("dh_vap_mass", None): 2169879.46248,  # 2169.8 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.479e-09,
+            ("boiling_point_elevation_phase", "Liq"): 0.94374,  # 0.944 K
+        }
+
+
+# T = 90C, salinity = 90 g/kg
+@pytest.mark.component
+class TestSeawaterPropertyTemp90Salinity90(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.93860506,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.092829072,
+            ("temperature", None): 273.15 + 90,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.90999,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.09,
+            ("dens_mass_phase", "Liq"): 1031.43413,
+            ("dens_mass_solvent", None): 965.24563,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 938.60506,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 92.82907,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 52.10049,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 2.95598,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.94631,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.05368,
+            ("molality_phase_comp", ("Liq", "TDS")): 3.14933,
+            ("visc_d_phase", "Liq"): 0.00039999,  # 0.0004 Pa-s
+            ("osm_coeff", None): 0.9523,
+            ("pressure_osm_phase", "Liq"): 8740862.18899,  # 8.741 MPa
+            ("enth_mass_phase", "Liq"): 336459.24947,  # 336.5 kJ/kg
+            ("energy_density_phase", "Liq"): 346935555.96049,
+            ("pressure_sat", None): 66238.94125,  # 66.239 kPa
+            ("cp_mass_phase", "Liq"): 3788.28386,  # 3788.3 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.66767,  # 0.668 W/m-K
+            ("dh_vap_mass", None): 2077246.1356,  # 2077.1 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.494e-09,
+            ("boiling_point_elevation_phase", "Liq"): 1.45011,  # 1.450 K
+        }
+
+
+# T = 120C, salinity = 120 g/kg, Q = 1 L/s
+@pytest.mark.component
+class TestSeawaterPropertyTemp120Salinity120(PropertyRegressionTest):
+    def configure(self):
+        self.prop_pack = props.SeawaterParameterBlock
+        self.param_args = {}
+
+        self.solver = "ipopt"
+        self.optarg = {"nlp_scaling_method": "user-scaling"}
+
+        self.scaling_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 1,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 10,
+        }
+        self.state_args = {
+            ("flow_mass_phase_comp", ("Liq", "H2O")): 0.90910769,
+            ("flow_mass_phase_comp", ("Liq", "TDS")): 0.12396923,
+            ("temperature", None): 273.15 + 120,
+            ("pressure", None): 1e5,
+        }
+        self.regression_solution = {
+            ("mass_frac_phase_comp", ("Liq", "H2O")): 0.88,
+            ("mass_frac_phase_comp", ("Liq", "TDS")): 0.12,
+            ("dens_mass_phase", "Liq"): 1033.07692,
+            ("dens_mass_solvent", None): 943.02132,
+            ("flow_vol_phase", "Liq"): 0.001,
+            ("conc_mass_phase_comp", ("Liq", "H2O")): 909.10769,
+            ("conc_mass_phase_comp", ("Liq", "TDS")): 123.96923,
+            ("flow_mol_phase_comp", ("Liq", "H2O")): 50.46314,
+            ("flow_mol_phase_comp", ("Liq", "TDS")): 3.94758,
+            ("mole_frac_phase_comp", ("Liq", "H2O")): 0.92744,
+            ("mole_frac_phase_comp", ("Liq", "TDS")): 0.07255,
+            ("molality_phase_comp", ("Liq", "TDS")): 4.34226,
+            ("visc_d_phase", "Liq"): 0.00032278,  # 0.000323 Pa-s
+            ("osm_coeff", None): 0.98462,
+            ("pressure_osm_phase", "Liq"): 13179594.05754,  # 13.180 MPa
+            ("enth_mass_phase", "Liq"): 427777.48946,  # 427.8 kJ/kg
+            ("energy_density_phase", "Liq"): 441827053.0114,
+            ("pressure_sat", None): 182600.72284,  # 182.601 kPa
+            ("cp_mass_phase", "Liq"): 3688.73469,  # 3688.8 J/kg-K
+            ("therm_cond_phase", "Liq"): 0.67781,  # 0.678 W/m-K
+            ("dh_vap_mass", None): 1937991.723,  # 1937.9 kJ/kg
+            ("diffus_phase_comp", ("Liq", "TDS")): 1.524e-09,
+            ("boiling_point_elevation_phase", "Liq"): 2.4623,  # 2.462 K
         }
 
 

--- a/watertap/property_models/tests/test_seawater_prop_pack.py
+++ b/watertap/property_models/tests/test_seawater_prop_pack.py
@@ -62,7 +62,7 @@ class TestSeawaterProperty(PropertyTestHarness):
             ("visc_d_phase", "Liq"): 9.588e-4,
             ("osm_coeff", None): 0.9068,
             ("pressure_osm_phase", "Liq"): 2.588e6,
-            ("enth_mass_phase", "Liq"): 9.896e4,
+            ("enth_mass_phase", "Liq"): 9.9766e4,
             ("pressure_sat", None): 3111,
             ("cp_mass_phase", "Liq"): 4001,
             ("therm_cond_phase", "Liq"): 0.6086,
@@ -107,8 +107,8 @@ class TestSeawaterPropertySolution_1(PropertyRegressionTest):
             ("visc_d_phase", "Liq"): 5.596e-4,
             ("osm_coeff", None): 0.9029,
             ("pressure_osm_phase", "Liq"): 7.710e5,
-            ("enth_mass_phase", "Liq"): 2.057e5,
-            ("energy_density_phase", "Liq"): 2.046e8,
+            ("enth_mass_phase", "Liq"): 2.06690e5,
+            ("energy_density_phase", "Liq"): 2.0555e8,
             ("pressure_sat", None): 1.229e4,
             ("cp_mass_phase", "Liq"): 4.130e3,
             ("therm_cond_phase", "Liq"): 0.6400,
@@ -153,8 +153,8 @@ class TestSeawaterPropertySolution_2(PropertyRegressionTest):
             ("visc_d_phase", "Liq"): 1.443e-3,
             ("osm_coeff", None): 0.9106,
             ("pressure_osm_phase", "Liq"): 3.591e6,
-            ("enth_mass_phase", "Liq"): 4.783e4,
-            ("energy_density_phase", "Liq"): 3.968e7,
+            ("enth_mass_phase", "Liq"): 4.8008e4,
+            ("energy_density_phase", "Liq"): 3.9865e7,
             ("pressure_sat", None): 1.194e3,
             ("cp_mass_phase", "Liq"): 3.916e3,
             ("therm_cond_phase", "Liq"): 0.5854,
@@ -290,7 +290,7 @@ class TestSeawaterCalculateState_5(PropertyCalculateStateTest):
         self.state_solution = {
             ("flow_mass_phase_comp", ("Liq", "H2O")): 9091.08,
             ("flow_mass_phase_comp", ("Liq", "TDS")): 1239.69,
-            ("enth_mass_phase", "Liq"): 3.8562e5,
+            ("enth_mass_phase", "Liq"): 4.36167e5,
         }
 
 

--- a/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
+++ b/watertap/unit_models/mvc/components/tests/test_chen_heat_exchanger.py
@@ -82,7 +82,7 @@ def test_heat_exchanger():
     results = solver.solve(m, tee=False)
     assert_optimal_termination(results)
 
-    assert pytest.approx(88038.104, rel=1e-4) == value(m.fs.unit.heat_duty[0])
+    assert pytest.approx(89046.45, rel=1e-4) == value(m.fs.unit.heat_duty[0])
     assert pytest.approx(1.0, rel=1e-4) == value(
         m.fs.unit.hot_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
     )
@@ -99,7 +99,7 @@ def test_heat_exchanger():
     assert pytest.approx(0.01, rel=1e-4) == value(
         m.fs.unit.cold_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
     )
-    assert pytest.approx(341.021, rel=1e-4) == value(
+    assert pytest.approx(340.777, rel=1e-4) == value(
         m.fs.unit.cold_outlet.temperature[0]
     )
     assert pytest.approx(2.0e5, rel=1e-4) == value(m.fs.unit.cold_outlet.pressure[0])

--- a/watertap/unit_models/mvc/components/tests/test_evaporator.py
+++ b/watertap/unit_models/mvc/components/tests/test_evaporator.py
@@ -114,7 +114,7 @@ def test_evaporator(evap_condense_model):
     # check values, TODO: make a report for the evaporator
     vapor_blk = m.fs.evaporator.properties_vapor[0]
     assert vapor_blk.flow_mass_phase_comp["Vap", "H2O"].value == pytest.approx(
-        0.4183, rel=1e-3
+        0.4174, rel=1e-3
     )
     assert m.fs.evaporator.lmtd.value == pytest.approx(13.79, rel=1e-3)
     assert m.fs.evaporator.heat_transfer.value == pytest.approx(1.379e6, rel=1e-3)
@@ -203,7 +203,7 @@ def test_evaporator_with_MCAS_mass_flow():
     # check values, TODO: make a report for the evaporator
     vapor_blk = m.fs.evaporator.properties_vapor[0]
     assert vapor_blk.flow_mass_phase_comp["Vap", "H2O"].value == pytest.approx(
-        0.4198, rel=1e-3
+        0.4176, rel=1e-3
     )
     assert m.fs.evaporator.lmtd.value == pytest.approx(13.79, rel=1e-3)
     assert m.fs.evaporator.heat_transfer.value == pytest.approx(1.379e6, rel=1e-3)
@@ -291,7 +291,7 @@ def test_evaporator_with_MCAS_mole_flow():
     # check values, TODO: make a report for the evaporator
     vapor_blk = m.fs.evaporator.properties_vapor[0]
     assert vapor_blk.flow_mass_phase_comp["Vap", "H2O"].value == pytest.approx(
-        0.4198, rel=1e-3
+        0.4176, rel=1e-3
     )
     assert m.fs.evaporator.lmtd.value == pytest.approx(13.79, rel=1e-3)
     assert m.fs.evaporator.heat_transfer.value == pytest.approx(1.379e6, rel=1e-3)

--- a/watertap/unit_models/mvc/tests/test_mvc.py
+++ b/watertap/unit_models/mvc/tests/test_mvc.py
@@ -116,13 +116,13 @@ def initialize(m, solver=None):
 
     # initialize evaporator
     m.fs.evaporator.initialize(
-        delta_temperature_in=30, delta_temperature_out=5, outlvl=idaeslog.INFO_HIGH
+        delta_temperature_in=30, delta_temperature_out=5, outlvl=idaeslog.WARNING
     )
 
     # initialize compressor
     propagate_state(m.fs.s01)
 
-    m.fs.compressor.initialize(outlvl=idaeslog.DEBUG)
+    m.fs.compressor.initialize(outlvl=idaeslog.WARNING)
 
     # initialize condenser
     propagate_state(m.fs.s02)
@@ -148,22 +148,18 @@ def test_mvc():
     assert_optimal_termination(results)
     brine_blk = m.fs.evaporator.properties_brine[0]
 
-    m.fs.compressor.report()
-    m.fs.condenser.report()
-    m.fs.evaporator.display()
-
     # evaporator values
     assert brine_blk.pressure.value == pytest.approx(1.9849e4, rel=1e-3)
-    assert m.fs.evaporator.lmtd.value == pytest.approx(26.1769036038, rel=1e-3)
+    assert m.fs.evaporator.lmtd.value == pytest.approx(26.73304769687, rel=1e-3)
     assert m.fs.evaporator.heat_transfer.value == pytest.approx(
-        10470761.441558, rel=1e-3
+        10693219.0787489, rel=1e-3
     )
 
     # compressor values
     compressed_blk = m.fs.compressor.control_volume.properties_out[0]
 
     assert m.fs.compressor.control_volume.work[0].value == pytest.approx(
-        500376.0409289, rel=1e-3
+        511322.1880571, rel=1e-3
     )
 
     assert compressed_blk.pressure.value == pytest.approx(39723.543091, rel=1e-3)
@@ -172,6 +168,6 @@ def test_mvc():
     # condenser values
     condensed_blk = m.fs.condenser.control_volume.properties_out[0]
     assert m.fs.condenser.control_volume.heat[0].value == pytest.approx(
-        -10470761.441558, rel=1e-3
+        -10693219.0787489, rel=1e-3
     )
-    assert condensed_blk.temperature.value == pytest.approx(339.13470452, rel=1e-3)
+    assert condensed_blk.temperature.value == pytest.approx(339.49583456, rel=1e-3)

--- a/watertap/unit_models/tests/test_membrane_distillation_0D.py
+++ b/watertap/unit_models/tests/test_membrane_distillation_0D.py
@@ -147,11 +147,11 @@ class TestMembraneDisillation0D(UnitTestHarness):
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.05209346659825
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 344.1024357724327
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.003345787450339149
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.5171083400694793
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7069605503451193
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.0520934
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 344.102435
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00334578745
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.517108340
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7069605503
 
         self.conservation_equality = {
             "Check 1": {

--- a/watertap/unit_models/tests/test_membrane_distillation_0D.py
+++ b/watertap/unit_models/tests/test_membrane_distillation_0D.py
@@ -96,6 +96,42 @@ def build():
     m.fs.unit.hot_ch.h_conv.fix(2400)
     m.fs.unit.cold_ch.h_conv.fix(2400)
 
+    m.fs.properties_hot_ch.set_default_scaling(
+        "flow_mass_phase_comp", 1, index=("Liq", "H2O")
+    )
+    m.fs.properties_hot_ch.set_default_scaling(
+        "flow_mass_phase_comp", 1e2, index=("Liq", "TDS")
+    )
+    m.fs.properties_cold_ch.set_default_scaling(
+        "flow_mass_phase_comp", 1, index=("Liq", "H2O")
+    )
+    m.fs.properties_cold_ch.set_default_scaling(
+        "flow_mass_phase_comp", 1e2, index=("Liq", "TDS")
+    )
+    m.fs.properties_vapor.set_default_scaling(
+        "flow_mass_phase_comp", 1, index=("Liq", "H2O")
+    )
+    m.fs.properties_vapor.set_default_scaling(
+        "flow_mass_phase_comp", 1, index=("Vap", "H2O")
+    )
+
+    iscale.set_scaling_factor(
+        m.fs.unit.cold_ch.properties_in[0].flow_mass_phase_comp["Vap", "H2O"], 1
+    )
+    iscale.set_scaling_factor(
+        m.fs.unit.cold_ch.properties_out[0].flow_mass_phase_comp["Vap", "H2O"], 1
+    )
+    iscale.set_scaling_factor(
+        m.fs.unit.cold_ch.properties_interface[0, 0].flow_mass_phase_comp["Vap", "H2O"],
+        1,
+    )
+    iscale.set_scaling_factor(
+        m.fs.unit.cold_ch.properties_interface[0, 1].flow_mass_phase_comp["Vap", "H2O"],
+        1,
+    )
+    iscale.set_scaling_factor(m.fs.unit.area, 1e-1)
+    iscale.set_scaling_factor(m.fs.unit.hot_ch.heat, 1e-3)
+    iscale.set_scaling_factor(m.fs.unit.cold_ch.heat, 1e-3)
     iscale.calculate_scaling_factors(m.fs.unit)
 
     return m
@@ -111,11 +147,11 @@ class TestMembraneDisillation0D(UnitTestHarness):
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 312.652577449503
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 343.401843712127
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.003356790
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.5268
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.69618
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.05209346659825
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 344.1024357724327
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.003345787450339149
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.5171083400694793
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7069605503451193
 
         self.conservation_equality = {
             "Check 1": {
@@ -197,15 +233,17 @@ class TestMembraneDisillation0D_temperature_polarization_none(UnitTestHarness):
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9016872
+        ] = 0.9033266209853699
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 301.76628
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.44918
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.01266
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.687139
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.819987
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 303.6704079347907
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
+            352.05089103799094
+        )
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.01233
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6633469
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8292445
 
         self.conservation_equality = {
             "Check 1": {
@@ -296,11 +334,11 @@ class TestMembraneDisillation0D_temperature_polarization_fixed(UnitTestHarness):
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 312.652577449503
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 343.401843712127
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.003356790
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.5268
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.69618
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.05609
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 344.10965
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00334521
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.51706
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.70707
 
         self.conservation_equality = {
             "Check 1": {
@@ -389,16 +427,16 @@ class TestMembraneDisillation0D_temperature_polarization_calculated(UnitTestHarn
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9002124090930
+        ] = 0.9029749
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.20215
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.806
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0053989
-        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.06713739
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.68575
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8408
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.03889
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.54345
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0051688
+        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.0642747
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.65
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.852207
 
         self.conservation_equality = {
             "Check 1": {
@@ -491,15 +529,15 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9005880857452575
+        ] = 0.903349276
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.2498
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.785
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0053676595
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.68237393
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8405494334
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.08527
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.522566
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00513756
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6466382
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8518856
 
         self.conservation_equality = {
             "Check 1": {
@@ -594,15 +632,15 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9015774522415636
+        ] = 0.9042205
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.377886
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.504663
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00528521
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6733963
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.83968273
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.19553
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.471809
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00506495
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6387468
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8511047
 
         self.conservation_equality = {
             "Check 1": {
@@ -697,16 +735,16 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9008354100672312
+        ] = 0.903569
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.3940
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.8690612
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00534704
-        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.066491803
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6800786
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.841831
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.22345
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.60605
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00511924
+        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.063659
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6446025
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.85317
 
         self.conservation_equality = {
             "Check 1": {
@@ -805,15 +843,15 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_concentratio
         self.unit_solutions[m.fs.unit.cold_ch.length] = 8
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9008354100672311
+        ] = 0.903569
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.3940665
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.86906
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00534704
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6800786
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8418317
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.22345
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.60605
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00511924
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6446025
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.85317
         self.unit_solutions[m.fs.unit.hot_ch.deltaP[0]] = -500000.0
         self.unit_solutions[m.fs.unit.cold_ch.deltaP[0]] = -500000.0
 
@@ -907,17 +945,17 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_concentratio
         self.unit_solutions[m.fs.unit.cold_ch.length] = 8
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9007196
+        ] = 0.903455
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 300.52407
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 352.84163
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00535669
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.6811818
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.841409
-        self.unit_solutions[m.fs.unit.hot_ch.deltaP[0]] = -301454.81094
-        self.unit_solutions[m.fs.unit.cold_ch.deltaP[0]] = -343467.7791
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 302.169
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 353.5788
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00512875
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.64568
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.85275
+        self.unit_solutions[m.fs.unit.hot_ch.deltaP[0]] = -299896.723878
+        self.unit_solutions[m.fs.unit.cold_ch.deltaP[0]] = -342521.37806
 
         self.conservation_equality = {
             "Check 1": {
@@ -992,9 +1030,9 @@ class TestMembraneDisillation0D_temperature_polarization_none_vmd(UnitTestHarnes
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9285175510218185
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 337.7047629447829
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 337.7047629447829
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03648244897818147
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 338.6605219221607
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 338.6605219221607
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.037008
 
         self.conservation_equality = {
             "Check 1": {
@@ -1070,9 +1108,9 @@ class TestMembraneDisillation0D_temperature_polarization_fixed_hot_vmd(UnitTestH
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9479100277176233
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 352.1551430126428
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 337.7492369004734
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.01708997228237665
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 352.655289
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 338.0086
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.017254657
 
         self.conservation_equality = {
             "Check 1": {
@@ -1153,9 +1191,9 @@ class TestMembraneDisillation0D_temperature_polarization_calculated_hot_vmd(
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9348449235681139
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 342.68302106371556
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.9911385947164
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03015507643188607
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 343.476969
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 340.669024
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03057997
 
         self.conservation_equality = {
             "Check 1": {
@@ -1238,9 +1276,9 @@ class TestMembraneDisillation0D_temperature_polarization_concentration_polarizat
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9348449235681139
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 342.68302106371556
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.9911385947164
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03004295222746866
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 343.558025
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 340.747587
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03046524
 
         self.conservation_equality = {
             "Check 1": {
@@ -1256,6 +1294,7 @@ class TestMembraneDisillation0D_temperature_polarization_concentration_polarizat
         return m
 
 
+#
 def build_temperature_polarization_concentration_polarization_pressure_calculated_hot_vmd():
     m = ConcreteModel()
     m.fs = FlowsheetBlock(dynamic=False)
@@ -1324,10 +1363,10 @@ class TestMembraneDisillation0D_temperature_polarization_concentration_polarizat
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9348449235681139
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 342.68302106371556
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.9911385947164
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03004295222746866
-        self.unit_solutions[m.fs.unit.hot_ch.deltaP[0]] = -73462.05019358391
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 343.56891
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 340.756717
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03047074
+        self.unit_solutions[m.fs.unit.hot_ch.deltaP[0]] = -73386.0456
 
         self.conservation_equality = {
             "Check 1": {
@@ -1428,7 +1467,7 @@ class TestMembraneDisillation0D_temperature_polarization_none_pgmd(UnitTestHarne
         self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
             304.69178989433595
         )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0023053139451937005
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.002318637
         self.unit_solutions[m.fs.unit.gap_ch_outlet.temperature[0]] = 326.62398751842414
 
         self.conservation_equality = {

--- a/watertap/unit_models/tests/test_membrane_distillation_1D.py
+++ b/watertap/unit_models/tests/test_membrane_distillation_1D.py
@@ -112,15 +112,15 @@ class TestMembraneDisillation1D(UnitTestHarness):
         ] = 0
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9294923084883953
+        ] = 0.9282725
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 313.4770191978068
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 342.8447987723201
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0029589742926337237
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.46958331303607553
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.6876122888049245
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.5297587
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 343.790759
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0030606
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4751264
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.702165528
 
         self.conservation_equality = {
             "Check 1": {
@@ -206,15 +206,15 @@ class TestMembraneDisillation1D_temperature_polarization_none(UnitTestHarness):
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9244443003141366
+        ] = 0.922776
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 307.4425600993805
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 347.7273575270859
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.008111139937172647
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4809369122475431
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7627285773397838
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 308.1848897
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 349.046787
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.008444798
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4870051
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7830275
 
         self.conservation_equality = {
             "Check 1": {
@@ -303,12 +303,12 @@ class TestMembraneDisillation1D_temperature_polarization_fixed(UnitTestHarness):
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.929497268800918
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 313.4706323418694
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 342.841898880965
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0029585609332568297
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.46956031608126614
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.6875676750917696
+        ] = 0.928775
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 314.523531
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 343.78807
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0030602
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4751043
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.7021242
 
         self.conservation_equality = {
             "Check 1": {
@@ -399,16 +399,16 @@ class TestMembraneDisillation1D_temperature_polarization_calculated(UnitTestHarn
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9233923911250498
+        ] = 0.92163799
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.337512844963
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 350.4583511214421
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0034673007395
-        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.0431166931346
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.467514426654
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.804743863406
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.028018
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.87209
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0036135
+        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.0449347
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.47367225
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8264937
 
         self.conservation_equality = {
             "Check 1": {
@@ -503,13 +503,13 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.923602738825
+        ] = 0.92185905
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.3575352876
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 350.4506210584
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0034497717645
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.049789
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.863122
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00359508
 
         self.conservation_equality = {
             "Check 1": {
@@ -605,17 +605,15 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9237376005292054
+        ] = 0.922
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.3676091577648
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
-            350.44794988928794
-        )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.003438533289232888
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4639450335411154
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8045838444505841
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.062335
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.85863
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00358303
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.47002591
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.826866
 
         self.conservation_equality = {
             "Check 1": {
@@ -711,16 +709,16 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_concentratio
 
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9234150642000756
+        ] = 0.921668829
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.4323257757313
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 350.5701165470125
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0034654113166603566
-        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.04309319772012876
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4671469978106365
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8064633314925004
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.125855
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.9792
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00361093
+        self.unit_solutions[m.fs.unit.recovery_mass[0]] = 0.0449028
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.47326646
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.82814152
 
         self.conservation_equality = {
             "Check 1": {
@@ -820,15 +818,15 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_concentratio
         self.unit_solutions[m.fs.unit.cold_ch.length] = 8
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.923415064200076
+        ] = 0.9216688
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.4323257757313
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 350.5701165470125
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0034654113166603523
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4671469978106365
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8064633314925004
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.125855
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.9792
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00361093
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4732665
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8281415
         self.unit_solutions[m.fs.unit.hot_ch.deltaP_channel[0]] = -500000.0
         self.unit_solutions[m.fs.unit.cold_ch.deltaP_channel[0]] = -500000.0
 
@@ -927,19 +925,17 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_concentratio
         self.unit_solutions[m.fs.unit.cold_ch.length] = 8
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 0.9234395262038794
+        ] = 0.9216924
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "TDS"]
         ] = 0.035
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 304.40094664041476
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
-            350.52705264537326
-        )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0034633728163433928
-        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4669795564991426
-        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.8058008099288198
-        self.unit_solutions[m.fs.unit.hot_ch.deltaP_channel[0]] = -297491.6707887916
-        self.unit_solutions[m.fs.unit.cold_ch.deltaP_channel[0]] = -332494.6036866968
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 305.093352
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 351.93729
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.00360897
+        self.unit_solutions[m.fs.unit.thermal_efficiency[0]] = 0.4731037
+        self.unit_solutions[m.fs.unit.effectiveness[0]] = 0.82749678
+        self.unit_solutions[m.fs.unit.hot_ch.deltaP_channel[0]] = -295331.803525
+        self.unit_solutions[m.fs.unit.cold_ch.deltaP_channel[0]] = -331332.910349
 
         self.conservation_equality = {
             "Check 1": {
@@ -1016,9 +1012,9 @@ class TestMembraneDisillation1D_temperature_polarization_none_vmd(UnitTestHarnes
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9333282339579946
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 341.6477118118322
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 341.6477118118322
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03167176604200531
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 342.25342
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 342.253422
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.03241786
 
         self.conservation_equality = {
             "Check 1": {
@@ -1096,11 +1092,11 @@ class TestMembraneDisillation1D_temperature_polarization_fixed_hot_vmd(UnitTestH
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9482002512081292
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 352.36321353466815
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 352.839383
         self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
             337.84769812257065
         )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.016799748791871325
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.016983716
 
         self.conservation_equality = {
             "Check 1": {
@@ -1182,9 +1178,9 @@ class TestMembraneDisillation1D_temperature_polarization_calculated_hot_vmd(
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9450790917786648
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.19642692723755
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.72706
         self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.2750084657155
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.019920908221335205
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.02018963
 
         self.conservation_equality = {
             "Check 1": {
@@ -1268,9 +1264,9 @@ class TestMembraneDisillation1D_temperature_polarization_concentration_polarizat
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9450790917786648
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.19642692723755
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.2750084657155
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.019769720894804336
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.82795
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.763283
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.020033
 
         self.conservation_equality = {
             "Check 1": {
@@ -1355,9 +1351,9 @@ class TestMembraneDisillation1D_temperature_polarization_concentration_polarizat
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9450790917786648
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.19642692723755
-        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.2750084657155
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.019769720894804336
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 350.827972
+        self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = 339.763298
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.020033
 
         self.conservation_equality = {
             "Check 1": {
@@ -1463,7 +1459,7 @@ class TestMembraneDisillation1D_temperature_polarization_none_pgmd(UnitTestHarne
         self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
             304.69178989433595
         )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0023053139451937005
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.002317366
         self.unit_solutions[m.fs.unit.gap_ch_outlet.temperature[0]] = 326.62398751842414
 
         self.conservation_equality = {
@@ -1587,12 +1583,12 @@ class TestMembraneDisillation1D_temperature_polarization_concentration_polarizat
         self.unit_solutions[
             m.fs.unit.hot_ch_outlet.flow_mass_phase_comp[0, "Liq", "H2O"]
         ] = 0.9580840582054698
-        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 356.6334998833635
+        self.unit_solutions[m.fs.unit.hot_ch_outlet.temperature[0]] = 357.132013
         self.unit_solutions[m.fs.unit.cold_ch_outlet.temperature[0]] = (
             304.69178989433595
         )
-        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.0022284349420104385
-        self.unit_solutions[m.fs.unit.gap_ch_outlet.temperature[0]] = 326.62398751842414
+        self.unit_solutions[m.fs.unit.flux_mass_avg[0]] = 0.002241485
+        self.unit_solutions[m.fs.unit.gap_ch_outlet.temperature[0]] = 327.03213
 
         self.conservation_equality = {
             "Check 1": {

--- a/watertap/unit_models/tests/test_pressure_changer.py
+++ b/watertap/unit_models/tests/test_pressure_changer.py
@@ -196,7 +196,7 @@ class TestPump(UnitTestHarness):
             298.15
         )
         self.unit_solutions[m.fs.unit.control_volume.properties_out[0].enth_flow] = (
-            9.931834173e4
+            100120.971507
         )
         self.unit_solutions[
             m.fs.unit.control_volume.properties_out[0].flow_mass_phase_comp[
@@ -241,7 +241,7 @@ class TestEnergyRecoveryDevice(UnitTestHarness):
             298.15
         )
         self.unit_solutions[m.fs.unit.control_volume.properties_out[0].enth_flow] = (
-            9.89617297e4
+            99764.35946
         )
         self.unit_solutions[
             m.fs.unit.control_volume.properties_out[0].flow_mass_phase_comp[
@@ -286,7 +286,7 @@ class TestPumpVariableFlow(UnitTestHarness):
             298.15
         )
         self.unit_solutions[m.fs.unit.control_volume.properties_out[0].enth_flow] = (
-            9.93183417e4
+            100120.9715067
         )
         self.unit_solutions[
             m.fs.unit.control_volume.properties_out[0].flow_mass_phase_comp[

--- a/watertap/unit_models/tests/test_steam_heater_0D.py
+++ b/watertap/unit_models/tests/test_steam_heater_0D.py
@@ -76,13 +76,11 @@ class TestSteamHeater0D(UnitTestHarness):
 
         self.unit_solutions[
             m.fs.unit.hot_side_inlet.flow_mass_phase_comp[0, "Vap", "H2O"]
-        ] = 0.7474967732076081
+        ] = 0.75240296
         self.unit_solutions[m.fs.unit.hot_side_outlet.temperature[0]] = (
             393.5672256519623
         )
-        self.unit_solutions[m.fs.unit.cold_side_outlet.temperature[0]] = (
-            340.9522230977077
-        )
+        self.unit_solutions[m.fs.unit.cold_side_outlet.temperature[0]] = 339.9562033
 
         self.conservation_equality = {
             "Check 1": {
@@ -109,10 +107,8 @@ class TestCondenserNoEstimation(UnitTestHarness):
         self.unit_solutions[m.fs.unit.hot_side_outlet.temperature[0]] = (
             393.5672256519623
         )
-        self.unit_solutions[m.fs.unit.cold_side_outlet.temperature[0]] = (
-            326.68592002256395
-        )
-        self.unit_solutions[m.fs.unit.area] = 6.129593261211377
+        self.unit_solutions[m.fs.unit.cold_side_outlet.temperature[0]] = 325.9693903
+        self.unit_solutions[m.fs.unit.area] = 6.104748
         self.unit_solutions[
             m.fs.unit.hot_side_inlet.flow_mass_phase_comp[0, "Vap", "H2O"]
         ] = 0.5
@@ -170,10 +166,10 @@ class TestCondenserwithEstimation(UnitTestHarness):
         self.unit_solutions[m.fs.unit.area] = 6.6472767942455455
         self.unit_solutions[
             m.fs.unit.cold_side_inlet.flow_mass_phase_comp[0, "Liq", "TDS"]
-        ] = 0.23938598366941452
+        ] = 0.232343867
         self.unit_solutions[
             m.fs.unit.cold_side_inlet.flow_mass_phase_comp[0, "Liq", "H2O"]
-        ] = 6.600213549742428
+        ] = 6.40605231
 
         self.conservation_equality = {
             "Check 1": {

--- a/watertap/unit_models/tests/unit_test_harness.py
+++ b/watertap/unit_models/tests/unit_test_harness.py
@@ -131,7 +131,7 @@ class UnitTestHarness(abc.ABC):
             unit=blk,
             solver=blk._test_objs.solver,
             optarg=blk._test_objs.optarg,
-            outlvl=idaeslog.DEBUG,
+            outlvl=idaeslog.WARNING,
         )
 
     @pytest.mark.component


### PR DESCRIPTION
## Fixes/Resolves:
#1855 

## Summary/Motivation:
Coefficients used to calculate enthalpy in the seawater property package were incorrect, as identified in issue #1855.

## Changes proposed in this PR:
- reintroduce e1 factors to the two coefficients
- add tests to SW prop and MCAS against data in https://web.mit.edu/seawater/2017_MIT_Seawater_Property_Tables_r2b_2023c.pdf


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
